### PR TITLE
Serializable Check to False

### DIFF
--- a/covid-mapper/store.js
+++ b/covid-mapper/store.js
@@ -2,10 +2,12 @@ import { configureStore } from "@reduxjs/toolkit";
 import { covidApi } from "./api/covidApi";
 
 export const store = configureStore({
-    reducer: {
-        [covidApi.reducerPath]:covidApi.reducer,
-    },
-    middleware: (getDefaultMiddleware) => {
-        return getDefaultMiddleware().concat(covidApi.middleware)
-    }
-})
+  reducer: {
+    [covidApi.reducerPath]: covidApi.reducer,
+  },
+  middleware: (getDefaultMiddleware) => {
+    return getDefaultMiddleware({ serializableCheck: false }).concat(
+      covidApi.middleware
+    );
+  },
+});


### PR DESCRIPTION
## Changes
1. Set the serializable check to false in the Redux store.

## Purpose
The serializable check in Redux store middleware should be disabled.

Closes #11 