### PR TITLE
Add screenOptions prop to Drawer to  hide status ba…

### DIFF
--- a/covid-mapper/features/drawer/DrawerMenu.js
+++ b/covid-mapper/features/drawer/DrawerMenu.js
@@ -4,6 +4,7 @@ import { createDrawerNavigator } from "@react-navigation/drawer";
 import { NavigationContainer } from "@react-navigation/native";
 import DrawerContent from "./DrawerContent";
 import DrawerButton from "../map-layout/components/DrawerButton";
+import { useWindowDimensions } from 'react-native';
 const Drawer = createDrawerNavigator();
 
 function WorldScreen({ navigation }) {
@@ -101,9 +102,15 @@ function AboutUsScreen({ navigation }) {
   );
 }
 const DrawerMenu = () => {
+  const dimensions = useWindowDimensions();
   return (
     <NavigationContainer>
-      <Drawer.Navigator initialRouteName="World" 
+      <Drawer.Navigator 
+      initialRouteName="World" 
+      screenOptions={{
+        drawerType: dimensions.width >= 768 ? 'permanent' : 'front',
+        drawerHideStatusBarOnOpen: true,
+      }}
       drawerContent={(props) => <DrawerContent {...props}/>}>
         {/* Component created for menu button test */}
      


### PR DESCRIPTION
…r when drawer is opened and change drawer type to permanent if screen is wider than 768

## Changes

1. Added `screenOptions` prop(object) to `Drawer.Navigator` to customize drawer type(set drawer to be permanent sidebar if screen is wider than 768px).
2. Set `drawerHideStatusBarOnOpen` to `true` to hide device's status bar(at the top of screen) when drawer's opened.
3. Import `useWindowDimensions` from `react-native` for `drawerType` ternary to work.
4. Initialized `dimensions` with `useWindowDimensions` hook.

## Purpose
Set some options for the drawer depending on screen width and drawer state.

## Approach
Add `screenOptions` prop to `Drawer.Navigator` component with options object passed in. 

## Learning
[useWindowDimensions](https://reactnative.dev/docs/usewindowdimensions)
![Screen Shot 2021-10-18 at 2 50 18 PM](https://user-images.githubusercontent.com/16534498/137812468-017414a3-8c4b-4279-ba17-ef0c0ce24ef5.png)
<img width="581" alt="Screen Shot 2021-10-18 at 2 57 52 PM" src="https://user-images.githubusercontent.com/16534498/137812472-61e23f70-7c8a-4839-9e67-fb31a0fa7e5f.png">

Closes #20 