### PR TITLE
Removed input string after submission

### DIFF
--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -61,7 +61,10 @@ const Searchbar = ({ handleSearchSubmit, searchPlaceholder }) => {
         onFocus={() => setIsFocus(true)}
         onBlur={() => setIsFocus(!searchInput.length ? false : true)}
         onChangeText={(text) => setSearchInput(text)}
-        onSubmitEditing={() => handleSearchSubmit(searchInput)}
+        onSubmitEditing={() => {
+          handleSearchSubmit(searchInput);
+          setSearchInput("");
+        }}
       />
     </SearchbarWrapper>
   );


### PR DESCRIPTION
## Changes
1. Set the search input state to an empty string after the user submits.

## Purpose
The input string after submission should default to an empty string, but instead holds the previous value.

Closes #46 