### PR TITLE
Made search bar icon simulate as a button

### DIFF
--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Pressable } from "react-native";
 import styled from "styled-components/native";
 
 const SearchbarWrapper = styled.View`
@@ -26,7 +27,8 @@ const SearchbarIconWrapper = styled.View`
 const SearchbarIcon = styled.Image`
   width: 100%;
   height: 100%;
-  opacity: ${({ isFocus }) => (isFocus ? "0.5" : "1")};
+  opacity: ${({ isFocus, isSearchIconPressedIn }) =>
+    isSearchIconPressedIn ? "1" : isFocus ? "0.5" : "1"};
 `;
 
 const SearchbarInput = styled.TextInput`
@@ -43,14 +45,25 @@ const SearchbarInput = styled.TextInput`
 const Searchbar = ({ handleSearchSubmit, searchPlaceholder }) => {
   const [searchInput, setSearchInput] = useState("");
   const [isFocus, setIsFocus] = useState(false);
+  const [isSearchIconPressedIn, setIsSearchIconPressedIn] = useState(false);
 
   return (
     <SearchbarWrapper>
       <SearchbarIconWrapper>
-        <SearchbarIcon
-          isFocus={isFocus}
-          source={require("../../assets/search-icon.png")}
-        />
+        <Pressable
+          onPressIn={() => setIsSearchIconPressedIn(true)}
+          onPressOut={() => setIsSearchIconPressedIn(false)}
+          onPress={() => {
+            handleSearchSubmit(searchInput);
+            setSearchInput("");
+          }}
+        >
+          <SearchbarIcon
+            isFocus={isFocus}
+            isSearchIconPressedIn={isSearchIconPressedIn}
+            source={require("../../assets/search-icon.png")}
+          />
+        </Pressable>
       </SearchbarIconWrapper>
 
       <SearchbarInput


### PR DESCRIPTION
## Changes
1. Created the search icon pressable for user to submission.
2. Created new states to dynamically update the opacity of the search icon.

## Purpose
When pressing on the searchbar icon, it should act as a button.

## Approach
In order to make the searchbar icon act as a button, a Native core component was used called `Pressable` which wraps around the `SearchbarIcon` component. An `onPress` prop was also used which fires the user's submission just like the `SearchbarInput` component, and a new state called `isSearchIconPressedIn` was created to dynamically update the searchbar icon's opacity. Whenever the user hits the icon, the `onPressIn` gets fired setting the `isSearchIconPressedIn` to true, but that same state gets set to false when the icon is not pressed firing the `onPressOut`.

## Learning
[Pressable - React Native Documentation](https://reactnative.dev/docs/pressable).

[Pressable: `onPressIn` - React Native Documentation](https://reactnative.dev/docs/pressable#onpressin).

[Pressable: `onPressOut` - React Native Documentation](https://reactnative.dev/docs/pressable#onpressout).

Closes #48 