### PR TITLE
Extracted data US county in `usCountiesData`

### DIFF
--- a/covid-mapper/features/map-layout/MapLayout.js
+++ b/covid-mapper/features/map-layout/MapLayout.js
@@ -15,25 +15,52 @@ import {
 import { OpenSesameButton } from "../../commons/components";
 import PopupSlider from "./components/PopupSlider";
 
+/**
+ * Finds the selected county inside an array of counties inside the US State.
+ * If it can't find the county, it return undefined. If it does, returns the county's
+ * data as an object.
+ * @param {String} county
+ * @param {Array<object>} stateCounties
+ * @returns {Null|object} Null or an object.
+ */
 const retrieveCountyData = (county, stateCounties) => {
+  // If the string length is empty, return undefined.
   if (!county.length) return null;
+  // Checks to see if it is undefined or null from the API.
   if (!stateCounties) return null;
+  // Checks to see if there is even an array length.
   if (!stateCounties.length) return null;
 
+  // Returns that county's data as an object, or undefined if nothing.
   const countyData = stateCounties.find((state) => state.county === county);
 
+  // Nullish coalescing operator that checks if it is undefined. If it is undefined,
+  // return null instead for better functionality checks in the future. If there is
+  // data, return that data.
   return countyData ?? null;
 };
 
 const MapLayout = ({ route }) => {
   const [mapDataArray, setMapDataArray] = useState([]);
   const [mapDataObject, setMapDataObject] = useState(null);
+  // This is to store the county data in this state after extraction:
   const [mapCountyDataObject, setMapCountyDataObject] = useState(null);
+
+  // This is to dynamically change the placeholder for the searchbar:
   const [searchPlaceholder, setSearchPlaceholder] = useState("");
+
+  // These are for storing the user's search inputs so that it could be inserted into
+  // the Redux Toolkit query hooks:
+  // -- for searching by country:
   const [searchCountry, setSearchCountry] = useState("");
+  // -- for searching by province:
   const [searchProvince, setSearchProvince] = useState("");
+  // -- for searching by US State:
   const [searchUSState, setSearchUSState] = useState("");
+  // -- for searching by US County in State (this would not be used in the query hooks,
+  // but to extract the array of data)
   const [searchUSCounty, setSearchUSCounty] = useState("");
+
   const { name: routeName } = route;
 
   const [testData, setTestData] = useState({
@@ -91,7 +118,7 @@ const MapLayout = ({ route }) => {
     data: usCountiesData,
     isLoading: usCountiesLoading,
     error: usCountiesError,
-  } = useGetAllUSCountiesFromStateQuery("california");
+  } = useGetAllUSCountiesFromStateQuery(searchUSState);
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
   const mapviewRegion = {
@@ -108,6 +135,8 @@ const MapLayout = ({ route }) => {
       if (!searchCountry.length && !searchProvince.length) {
         setSearchCountry(inputValue);
         setSearchPlaceholder("Search by province");
+
+        // This would only happen only if the user has provided a country search:
       } else {
         setSearchProvince(inputValue);
       }
@@ -164,7 +193,7 @@ const MapLayout = ({ route }) => {
 
       <OpenSesameButton />
 
-      {/* <PopupSlider testData={testData} /> */}
+      <PopupSlider testData={testData} />
 
       <MapComponent
         mapviewHeight={mapviewHeight}


### PR DESCRIPTION
## Changes
1. Created a function that extracts the county from an array of counties in a US State in order to display to the user.
2. Added documentations for better clarity.

## Purpose
When the user types in a county, that data should be displayed.

## Approach
Once the user types in the name of the US State, the `getAllUSCountiesFromState` endpoint would get fired that returns an array of available counties in the selected US State. But, what if the user wants to select a county in that State? The JSON layout for `/v3/covid-19/historical/usacounties/{state}` looks like this:

```
[
  {
    "province": "string",
    "county": "string",
    "timeline": {
      "cases": {
        "date": 0
      },
      "deaths": {
        "date": 0
      },
      "recovered": {
        "date": 0
      }
    }
  }
]
```

Another endpoint on just getting the data from a county (`/v3/covid-19/jhucsse/counties/{county}`) looks like this:

```
[
  {
    "country": "US",
    "province": "California",
    "county": "Fresno",
    "updatedAt": "2021-10-21 04:21:18",
    "stats": {
      "confirmed": 145503,
      "deaths": 2073,
      "recovered": null
    },
    "coordinates": {
      "latitude": "36.75733899",
      "longitude": "-119.6466953"
    }
  }
]
```

The downside to `/v3/covid-19/jhucsse/counties/{county}` is that it only shows the current day's data, and the upside to `/v3/covid-19/historical/usacounties/{state}` is that it displays all the timelines from all the counties from a particular US State. So, using the endpoint `/v3/covid-19/historical/usacounties/{state}` seems more reasonable on displaying a detail data to the user. Perhaps in the future, we would use the `/v3/covid-19/jhucsse/counties/{county}` endpoint to its `coordinates` property.

Once this decision on choosing an API was over, a function called `retrieveCountyData` was created which retrieves the county's data from an array of counties in the US State. If the county the user typed in was not inside the array, then the function return `null`. To activate this function, a `useEffect` was also created to fire when the user's searched US county was chosen (`searchUSCounty`), and when the `usCountiesData` from the `getAllUSCountiesFromState` query hook returns an array.

Lastly, comments were placed to better document on what is happening on this complicated file.

Closes #56 