### PR TITLE
Re-fetching on demand with `refetch`

### DIFF
--- a/covid-mapper/features/map-layout/MapLayout.js
+++ b/covid-mapper/features/map-layout/MapLayout.js
@@ -107,11 +107,13 @@ const MapLayout = ({ route }) => {
     data: countryHistoricalData,
     isLoading: countryHistoricalLoading,
     error: countryHistoricalError,
+    refetch: refetchCountryHistorical,
   } = useGetCountryHistoricalQuery(searchCountry);
   const {
     data: provinceHistoricalData,
     isLoading: provinceHistoricalLoading,
     error: provinceHistoricalError,
+    refetch: refetchProvinceHistorical,
   } = useGetProvinceHistoricalQuery({
     country: searchCountry,
     province: searchProvince,
@@ -135,6 +137,7 @@ const MapLayout = ({ route }) => {
     data: usCountiesData,
     isLoading: usCountiesLoading,
     error: usCountiesError,
+    refetch: refetchUSCounties,
   } = useGetAllUSCountiesFromStateQuery(searchUSState);
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
@@ -279,6 +282,8 @@ const MapLayout = ({ route }) => {
       setSliderDataLoading(countryHistoricalLoading);
 
       setSliderHeader(`${searchCountry} Data`);
+
+      refetchCountryHistorical();
     }
   }, [searchCountry, countryHistoricalData]);
 
@@ -300,6 +305,8 @@ const MapLayout = ({ route }) => {
       setSliderDataLoading(provinceHistoricalLoading);
 
       setSliderHeader(`${searchProvince} Data`);
+
+      refetchProvinceHistorical();
     }
   }, [searchProvince, provinceHistoricalData]);
 
@@ -322,6 +329,8 @@ const MapLayout = ({ route }) => {
       setSliderDataLoading(usCountiesLoading);
 
       setSliderHeader(`${searchUSState} Data`);
+
+      refetchUSCounties();
     }
   }, [searchUSState, usCountiesData]);
 


### PR DESCRIPTION
## Changes
1. Used Redux Toolkit's `refetch` function to refetch the API so that the Slider could be updated.

## Purpose
When the user enters a new location, the data should be updated.

## Approach
Since the data in the Slider was not being updated after the user submitted a country/state/province, the approach was to use the `refetch` function which force refetch the associated query so that the Slider could be changed based on the new user input value.

## Learning
[Cache Behavior: Re-fetching on demand with refetch/initiate - Redux Toolkit documentation](https://redux-toolkit.js.org/rtk-query/usage/cache-behavior#re-fetching-on-demand-with-refetchinitiate).

Closes #102 