### PR TITLE
Searchbar and PreviousRegion Button Position

### DIFF
--- a/covid-mapper/commons/components/FloatingSearchButton/FloatingSearchButton.js
+++ b/covid-mapper/commons/components/FloatingSearchButton/FloatingSearchButton.js
@@ -9,7 +9,7 @@ const FloatingSearchButton=({pressHandler})=>{
           style={{
             position: "absolute",
             right: "6%",
-            top: "7%",
+            top: "3%",
             zIndex: 10,
           }}
         >

--- a/covid-mapper/commons/components/PreviousRegionButton/PreviousRegionButton.js
+++ b/covid-mapper/commons/components/PreviousRegionButton/PreviousRegionButton.js
@@ -28,7 +28,7 @@ const PreviousRegionButton = ({
     <Pressable
       style={{
         position: "absolute",
-        top: "17%",
+        top: "12%",
         left: "10%",
         zIndex: 10,
       }}

--- a/covid-mapper/commons/components/PreviousRegionButton/styles.js
+++ b/covid-mapper/commons/components/PreviousRegionButton/styles.js
@@ -4,7 +4,7 @@ export const PreviousRegionWrapper = styled.View`
   height: 25px;
   padding-right: 10px;
   padding-left: 10px;
-  background-color: #fbfbfc;
+  background-color: #808B89;
   border: 0.5px solid #c6c6d1;
   border-radius: 50px;
   align-items: center;
@@ -13,5 +13,5 @@ export const PreviousRegionWrapper = styled.View`
 
 export const PreviousRegionTitle = styled.Text`
   font-size: 10px;
-  color: black;
+  color: #fafafa;
 `;

--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -33,7 +33,7 @@ const Searchbar = ({ handleSearchSubmit, searchPlaceholder, opacityLevel, handle
   const [isSearchIconPressedIn, setIsSearchIconPressedIn] = useState(false);
 
   return (
-    <Animated.View style={[styles.searchBarWrapper, {opacity: opacityLevel}]}>
+    <Animated.View style={[styles.searchBarWrapper, {opacity: opacityLevel, position: 'absolute', top: '3%'}]}>
         <SearchbarIconWrapper>
           <Pressable
             onPressIn={() => setIsSearchIconPressedIn(true)}


### PR DESCRIPTION
## Changes
1. Adjust `searchbar` and `previousRegionButton` position to refrain from obstructing the map view. 

## Purpose
For the search bar to be closer to the navigation bar to better fit the screen layout of the app.



Closes #116