### PR TITLE
Add onPressOut to call Keyboard.dismiss() 

### DIFF
--- a/covid-mapper/features/map-layout/MapLayout.js
+++ b/covid-mapper/features/map-layout/MapLayout.js
@@ -6,7 +6,7 @@ import React, {
   useMemo,
 } from "react";
 import * as Location from "expo-location";
-import { useWindowDimensions, Animated, Pressable } from "react-native";
+import { useWindowDimensions, Animated, Pressable, Keyboard } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
@@ -404,11 +404,13 @@ const MapLayout = ({ route }) => {
           snapPoints={snapPoints}
         />
 
-        <MapComponent
-          mapviewHeight={mapviewHeight}
-          mapviewRegion={mapRegion}
-          mapviewWidth={mapviewWidth}
-        />
+        <Pressable onPressOut={Keyboard.dismiss}>
+          <MapComponent
+            mapviewHeight={mapviewHeight}
+            mapviewRegion={mapRegion}
+            mapviewWidth={mapviewWidth}
+          />
+        </Pressable>
       </BottomSheetModalProvider>
     </>
   );


### PR DESCRIPTION

## Changes
1. Wrapped `Map` component with `Pressable` in `MapLayout`.
2. Add `onPressOut` to invoke `Keyboard.dismiss()`.

## Purpose
Dismiss keyboard when user taps on the map.

## Approach
React native. 

Closes #72 