### PR TITLE
Eg 121 population date properties

### DIFF
--- a/covid-mapper/api/covidApi.js
+++ b/covid-mapper/api/covidApi.js
@@ -19,6 +19,8 @@ export const covidApi = createApi({
         provinces: "",
         state: "",
         county: "",
+        updatedAt: response.cases ?? 0,
+        population: response.population ?? 0,
       }),
     }),
     getEachCountriesTotals: builder.query({
@@ -44,6 +46,8 @@ export const covidApi = createApi({
           provinces: "",
           state: state.state,
           county: "",
+          updatedAt: response.cases ?? 0,
+          population: response.population ?? 0,
         })),
     }),
     getTotalOneUSState: builder.query({
@@ -65,6 +69,8 @@ export const covidApi = createApi({
         provinces: "",
         state: response.state,
         county: "",
+        updatedAt: response.cases ?? 0,
+        population: response.population ?? 0,
       }),
     }),
 
@@ -79,6 +85,8 @@ export const covidApi = createApi({
         provinces: "",
         state: "",
         county: "",
+        updatedAt: response.cases ?? 0,
+        population: response.population ?? 0,
       }),
     }),
     getCountryHistorical: builder.query({
@@ -101,6 +109,8 @@ export const covidApi = createApi({
           .join(", "),
         state: "",
         county: "",
+        updatedAt: response.cases ?? 0,
+        population: response.population ?? 0,
       }),
     }),
     getCountriesHistorical: builder.query({
@@ -131,6 +141,8 @@ export const covidApi = createApi({
         provinces: capitalize(response.province, true),
         state: "",
         county: "",
+        updatedAt: response.cases ?? 0,
+        population: response.population ?? 0,
       }),
     }),
     getProvincesHistorical: builder.query({
@@ -157,6 +169,8 @@ export const covidApi = createApi({
           provinces: "",
           state: "",
           county: capitalize(county.county, true),
+          updatedAt: response.cases ?? 0,
+          population: response.population ?? 0,
         })),
     }),
 

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
@@ -89,9 +89,11 @@ const PopupSlider = ({
             county={sliderData.county}
             deaths={sliderData.deaths}
             hasTimelineSequence={sliderData.hasTimelineSequence}
+            population={sliderData.population}
             provinces={sliderData.provinces}
             recovered={sliderData.recovered}
             state={sliderData.state}
+            updatedAt={sliderData.updatedAt}
           />
         </BottomSheetScrollView>
       ) : (
@@ -105,9 +107,11 @@ const PopupSlider = ({
               county={item.county}
               deaths={item.deaths}
               hasTimelineSequence={item.hasTimelineSequence}
+              population={item.population}
               provinces={item.provinces}
               recovered={item.recovered}
               state={item.state}
+              updatedAt={item.updatedAt}
             />
           )}
         />

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
@@ -38,16 +38,22 @@ const PopupSliderData = ({
   county,
   deaths,
   hasTimelineSequence,
+  population,
   provinces,
   recovered,
   state,
+  updatedAt,
 }) => (
   <SliderDataWrapper>
-    <SliderDataPopulation>
-      400 million population size, Merica!!!!
-    </SliderDataPopulation>
+    {population > 0 && (
+      <SliderDataPopulation>
+        {numSeparator(population)} total population size
+      </SliderDataPopulation>
+    )}
 
-    <SliderDataUpdate>(updated on {Date(new Date())})</SliderDataUpdate>
+    {updatedAt > 0 && (
+      <SliderDataUpdate>(updated on {updatedAt})</SliderDataUpdate>
+    )}
 
     <SliderDataInfo>
       {provinces.length > 0 && (


### PR DESCRIPTION
## Changes
1. Added two new properties for the API data output for date update and population size.
2. Rendered the date update and population in the Slider.

## Purpose
The user needs to know how much population a selected region has, and the date the data has been updated.

## Approach
Since the user needs to know what is the population size of the selected region, and when the data had been updated, two new properties were added in `covidApi` called `updatedAt` and `population`. Since these properties might not exist on a certain endpoint, the nullish coalescing operator was used to check if it exists, and if not then it becomes 0. The last step was to render out these properties for the user if those properties were provided from the API.

Closes #121 