### PR TITLE
Refactored Slider Functionalities

### DIFF
--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -1,60 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { Modal, Pressable, Text, View } from "react-native";
-import styled from "styled-components/native";
+import { Modal, Pressable } from "react-native";
 
-const ModalOverlay = styled.View`
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-`;
-
-const ModalWrapper = styled.View`
-  display: flex;
-  position: absolute;
-  top: 30%;
-  left: 10%;
-  justify-content: space-around;
-  align-items: center;
-  width: 80%;
-  height: 250px;
-  padding: 20px;
-  background-color: white;
-  border-radius: 20px;
-  z-index: 10;
-`;
-
-const ModalHeader = styled.View`
-  margin-bottom: 10px;
-`;
-
-const ModalHeaderText = styled.Text`
-  font-size: 20px;
-  font-weight: bold;
-`;
-
-const ModalContent = styled.View`
-  margin-bottom: 20px;
-  padding-right: 10px;
-  padding-left: 10px;
-  text-align: left;
-`;
-
-const ModalContentText = styled.Text`
-  font-size: 16px;
-`;
-
-const ModalCloseButton = styled(Pressable)`
-  justify-content: center;
-  align-items: center;
-  width: 95%;
-  padding: 10px;
-  border: 1px solid #c6c6d1;
-  border-radius: 50px;
-`;
-
-const ModalCloseButtonText = styled.Text`
-  font-size: 16px;
-  color: blue;
-`;
+import {
+  ModalCloseButton,
+  ModalCloseButtonText,
+  ModalContent,
+  ModalContentText,
+  ModalHeader,
+  ModalHeaderText,
+  ModalOverlay,
+  ModalWrapper,
+} from "./styles";
 
 const ErrorModal = ({ error }) => {
   const [modalVisible, setModalVisible] = useState(false);

--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+import { Modal, Pressable, Text, View } from "react-native";
+import styled from "styled-components/native";
+
+const ModalOverlay = styled.View`
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const ModalWrapper = styled.View`
+  display: flex;
+  position: absolute;
+  top: 30%;
+  left: 10%;
+  justify-content: space-around;
+  align-items: center;
+  width: 80%;
+  height: 250px;
+  padding: 20px;
+  background-color: white;
+  border-radius: 20px;
+  z-index: 10;
+`;
+
+const ModalHeader = styled.View`
+  margin-bottom: 10px;
+`;
+
+const ModalHeaderText = styled.Text`
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+const ModalContent = styled.View`
+  margin-bottom: 20px;
+  padding-right: 10px;
+  padding-left: 10px;
+  text-align: left;
+`;
+
+const ModalContentText = styled.Text`
+  font-size: 16px;
+`;
+
+const ModalCloseButton = styled(Pressable)`
+  justify-content: center;
+  align-items: center;
+  width: 95%;
+  padding: 10px;
+  border: 1px solid #c6c6d1;
+  border-radius: 50px;
+`;
+
+const ModalCloseButtonText = styled.Text`
+  font-size: 16px;
+  color: blue;
+`;
+
+const ErrorModal = ({ error }) => {
+  const [modalVisible, setModalVisible] = useState(false);
+  console.log(error);
+
+  useEffect(() => {
+    if (error) {
+      setModalVisible(true);
+    }
+  }, [error]);
+
+  return (
+    <Modal
+      animationType="none"
+      transparent={true}
+      visible={modalVisible}
+      onRequestClose={() => setModalVisible(!modalVisible)}
+    >
+      <Pressable onPress={() => setModalVisible(!modalVisible)}>
+        <ModalOverlay></ModalOverlay>
+      </Pressable>
+
+      <ModalWrapper>
+        <ModalHeader>
+          <ModalHeaderText>Error</ModalHeaderText>
+        </ModalHeader>
+
+        <ModalContent>
+          <ModalContentText>
+            Country not found or doesn't have any historical data
+          </ModalContentText>
+        </ModalContent>
+
+        <ModalCloseButton
+          style={({ pressed }) => ({
+            backgroundColor: pressed ? "#c6c6d1" : "white",
+          })}
+          onPress={() => setModalVisible(!modalVisible)}
+        >
+          <ModalCloseButtonText>Close</ModalCloseButtonText>
+        </ModalCloseButton>
+      </ModalWrapper>
+    </Modal>
+  );
+};
+
+export default ErrorModal;

--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -58,7 +58,6 @@ const ModalCloseButtonText = styled.Text`
 
 const ErrorModal = ({ error }) => {
   const [modalVisible, setModalVisible] = useState(false);
-  console.log(error);
 
   useEffect(() => {
     if (error) {
@@ -84,7 +83,7 @@ const ErrorModal = ({ error }) => {
 
         <ModalContent>
           <ModalContentText>
-            Country not found or doesn't have any historical data
+            {error?.data?.message ? error.data.message : ""}
           </ModalContentText>
         </ModalContent>
 

--- a/covid-mapper/commons/components/ErrorModal/index.js
+++ b/covid-mapper/commons/components/ErrorModal/index.js
@@ -1,0 +1,1 @@
+export { default as ErrorModal } from "./ErrorModal";

--- a/covid-mapper/commons/components/ErrorModal/styles.js
+++ b/covid-mapper/commons/components/ErrorModal/styles.js
@@ -1,0 +1,53 @@
+export const ModalOverlay = styled.View`
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+export const ModalWrapper = styled.View`
+  display: flex;
+  position: absolute;
+  top: 30%;
+  left: 10%;
+  justify-content: space-around;
+  align-items: center;
+  width: 80%;
+  height: 250px;
+  padding: 20px;
+  background-color: white;
+  border-radius: 20px;
+  z-index: 10;
+`;
+
+export const ModalHeader = styled.View`
+  margin-bottom: 10px;
+`;
+
+export const ModalHeaderText = styled.Text`
+  font-size: 20px;
+  font-weight: bold;
+`;
+
+export const ModalContent = styled.View`
+  margin-bottom: 20px;
+  padding-right: 10px;
+  padding-left: 10px;
+  text-align: left;
+`;
+
+export const ModalContentText = styled.Text`
+  font-size: 16px;
+`;
+
+export const ModalCloseButton = styled(Pressable)`
+  justify-content: center;
+  align-items: center;
+  width: 95%;
+  padding: 10px;
+  border: 1px solid #c6c6d1;
+  border-radius: 50px;
+`;
+
+export const ModalCloseButtonText = styled.Text`
+  font-size: 16px;
+  color: blue;
+`;

--- a/covid-mapper/features/map-layout/MapLayout.js
+++ b/covid-mapper/features/map-layout/MapLayout.js
@@ -375,10 +375,7 @@ const MapLayout = ({ route }) => {
       <BottomSheetModalProvider>
         <PopupSlider
           sliderData={sliderData}
-          sliderDataLoading={sliderDataLoading}
-          sliderDataError={sliderDataError}
           sliderHeader={sliderHeader}
-          handlePresentModalPress={handlePresentModalPress}
           bottomSheetModalRef={bottomSheetModalRef}
           snapPoints={snapPoints}
         />

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components/native";
-import Spinner from "../../../../commons/components/Spinner/Spinner";
 import {
   BottomSheetModal,
   BottomSheetFlatList,
@@ -34,39 +33,10 @@ const PopupContent = styled.Text`
 
 const PopupSlider = ({
   sliderData,
-  sliderDataLoading,
-  sliderDataError,
   sliderHeader,
   snapPoints,
   bottomSheetModalRef,
 }) => {
-  if (sliderDataLoading)
-    return (
-      <BottomSheetModal>
-        <PopupContentContainer>
-          <PopupContent>
-            <Spinner />
-          </PopupContent>
-        </PopupContentContainer>
-      </BottomSheetModal>
-    );
-
-  if (sliderDataError) {
-    return (
-      <BottomSheetModal
-        ref={bottomSheetModalRef}
-        index={1}
-        snapPoints={snapPoints}
-      >
-        <PopupContentContainer>
-          <PopupContent>
-            Error {sliderDataError.status}: {sliderDataError.data.message}
-          </PopupContent>
-        </PopupContentContainer>
-      </BottomSheetModal>
-    );
-  }
-
   if (!sliderData) return null;
 
   return (

--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Pressable, Animated, StyleSheet, Keyboard } from "react-native";
 import styled from "styled-components/native";
 
-
 const SearchbarIconWrapper = styled.View`
   position: absolute;
   left: 5%;
@@ -27,64 +26,75 @@ const SearchbarInput = styled.TextInput`
   border-radius: 50px;
 `;
 
-const Searchbar = ({ handleSearchSubmit, searchPlaceholder, opacityLevel, handlePresentModalPress }) => {
+const Searchbar = ({
+  handleSearchSubmit,
+  searchPlaceholder,
+  opacityLevel,
+  handlePresentModalPress,
+}) => {
   const [searchInput, setSearchInput] = useState("");
   const [isFocus, setIsFocus] = useState(false);
   const [isSearchIconPressedIn, setIsSearchIconPressedIn] = useState(false);
 
   return (
-    <Animated.View style={[styles.searchBarWrapper, {opacity: opacityLevel, position: 'absolute', top: '3%'}]}>
-        <SearchbarIconWrapper>
-          <Pressable
-            onPressIn={() => setIsSearchIconPressedIn(true)}
-            onPressOut={() => setIsSearchIconPressedIn(false)}
-            onPress={() => {
-              handleSearchSubmit(searchInput);
-              setSearchInput("");
-              handlePresentModalPress()
-              Keyboard.dismiss()
-            }}
-          >
-            <SearchbarIcon
-              isFocus={isFocus}
-              isSearchIconPressedIn={isSearchIconPressedIn}
-              source={require("../../assets/search-icon.png")}
-            />
-          </Pressable>
-        </SearchbarIconWrapper>
-
-        <SearchbarInput
-          defaultValue=""
-          value={searchInput}
-          placeholder={searchPlaceholder}
-          isFocus={isFocus}
-          onFocus={() => setIsFocus(true)}
-          onBlur={() => setIsFocus(!searchInput.length ? false : true)}
-          onChangeText={(text) => setSearchInput(text)}
-          onSubmitEditing={() => {
+    <Animated.View
+      style={[
+        styles.searchBarWrapper,
+        { opacity: opacityLevel, position: "absolute", top: "3%" },
+      ]}
+    >
+      <SearchbarIconWrapper>
+        <Pressable
+          onPressIn={() => setIsSearchIconPressedIn(true)}
+          onPressOut={() => setIsSearchIconPressedIn(false)}
+          onPress={() => {
             handleSearchSubmit(searchInput);
             setSearchInput("");
+            handlePresentModalPress();
+            Keyboard.dismiss();
           }}
-        />
+        >
+          <SearchbarIcon
+            isFocus={isFocus}
+            isSearchIconPressedIn={isSearchIconPressedIn}
+            source={require("../../assets/search-icon.png")}
+          />
+        </Pressable>
+      </SearchbarIconWrapper>
+
+      <SearchbarInput
+        defaultValue=""
+        value={searchInput}
+        placeholder={searchPlaceholder}
+        isFocus={isFocus}
+        onFocus={() => setIsFocus(true)}
+        onBlur={() => setIsFocus(!searchInput.length ? false : true)}
+        onChangeText={(text) => setSearchInput(text)}
+        onSubmitEditing={() => {
+          handleSearchSubmit(searchInput);
+          handlePresentModalPress();
+          setSearchInput("");
+        }}
+      />
     </Animated.View>
   );
 };
 
-const styles=StyleSheet.create({
+const styles = StyleSheet.create({
   searchBarWrapper: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'absolute',
-    top: '7%',
-    left: '20%',
-    width: '60%',
+    justifyContent: "center",
+    alignItems: "center",
+    position: "absolute",
+    top: "7%",
+    left: "20%",
+    width: "60%",
     height: 50,
-    backgroundColor: '#fbfbfc',
+    backgroundColor: "#fbfbfc",
     borderWidth: 1,
     borderColor: "#f0f0f3",
     borderRadius: 50,
     zIndex: 10,
-  }
-})
+  },
+});
 
 export default Searchbar;

--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Pressable, Animated, StyleSheet, Keyboard } from "react-native";
 import styled from "styled-components/native";
+import Spinner from "../../commons/components/Spinner/Spinner";
 
 const SearchbarIconWrapper = styled.View`
   position: absolute;
@@ -26,11 +27,17 @@ const SearchbarInput = styled.TextInput`
   border-radius: 50px;
 `;
 
+const SearchbarSpinnerLoading = styled.View`
+  position: absolute;
+  right: 5%;
+`;
+
 const Searchbar = ({
   handleSearchSubmit,
   searchPlaceholder,
   opacityLevel,
   handlePresentModalPress,
+  sliderDataLoading,
 }) => {
   const [searchInput, setSearchInput] = useState("");
   const [isFocus, setIsFocus] = useState(false);
@@ -76,6 +83,12 @@ const Searchbar = ({
           setSearchInput("");
         }}
       />
+
+      {sliderDataLoading && (
+        <SearchbarSpinnerLoading>
+          <Spinner />
+        </SearchbarSpinnerLoading>
+      )}
     </Animated.View>
   );
 };

--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -37,7 +37,7 @@ const Searchbar = ({
   searchPlaceholder,
   opacityLevel,
   handlePresentModalPress,
-  sliderDataLoading,
+  dataLoading,
 }) => {
   const [searchInput, setSearchInput] = useState("");
   const [isFocus, setIsFocus] = useState(false);
@@ -84,7 +84,7 @@ const Searchbar = ({
         }}
       />
 
-      {sliderDataLoading && (
+      {dataLoading && (
         <SearchbarSpinnerLoading>
           <Spinner />
         </SearchbarSpinnerLoading>


### PR DESCRIPTION
## Changes
1. Opened the Slider after keyboard submission so that the user does not need to hit the searchbar icon.
2. Moved the loading spinner outside of the Slider and to the Searchbar for better UI.
3. Moved the API errors from Slider into its own Modal for better UI.

## Purpose
The Slider should appear without clicking on the searchbar icon, and the loading and error should be displayed outside of the Slider.

## Approach
One of the issues was that in order for the Slider to open when entering a location, they would have to use use the searchbar icon. Yet, what if the user uses their keyboard? How would they open the Slider? The simple fix was to add the `handlePresentModalPress` prop in `SearchbarInput` for the `Searchbar.js` file, and this way when the user uses their keyboard and hit enter, the Slider would appear without using the searchbar icon.

For the errors, to create a better UI experience, instead of rendering the errors inside the Slider, a new component of  `ErrorModal` was created to render any errors on the screen for the user. The user could either click on the overlay or on the close button to exit the modal.

For another better UI experience, instead of rendering the loading spinner when the API is being fetched inside the Slider, the spinner was added inside the Searchbar. It appears at the right-end side of the component.

Closes #131 
Closes #133 