### PR TITLE
Fixed the API error when APIs are fetched and fixed Searchbar input to not proceed any further if there are errors

### DIFF
--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -12,7 +12,7 @@ import {
   ModalWrapper,
 } from "./styles";
 
-const ErrorModal = ({ errorMsg, errorStatus }) => {
+const ErrorModal = ({ errorMsg, errorStatus, setDataError }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
@@ -25,9 +25,23 @@ const ErrorModal = ({ errorMsg, errorStatus }) => {
       animationType="none"
       transparent={true}
       visible={modalVisible}
-      onRequestClose={() => setModalVisible(!modalVisible)}
+      onRequestClose={() => {
+        setDataError({
+          error: false,
+          message: "",
+        });
+        setModalVisible(!modalVisible);
+      }}
     >
-      <Pressable onPress={() => setModalVisible(!modalVisible)}>
+      <Pressable
+        onPress={() => {
+          setDataError({
+            error: false,
+            message: "",
+          });
+          setModalVisible(!modalVisible);
+        }}
+      >
         <ModalOverlay></ModalOverlay>
       </Pressable>
 
@@ -44,7 +58,13 @@ const ErrorModal = ({ errorMsg, errorStatus }) => {
           style={({ pressed }) => ({
             backgroundColor: pressed ? "#c6c6d1" : "white",
           })}
-          onPress={() => setModalVisible(!modalVisible)}
+          onPress={() => {
+            setDataError({
+              error: false,
+              message: "",
+            });
+            setModalVisible(!modalVisible);
+          }}
         >
           <ModalCloseButtonText>Close</ModalCloseButtonText>
         </ModalCloseButton>

--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -12,14 +12,13 @@ import {
   ModalWrapper,
 } from "./styles";
 
-const ErrorModal = ({ error }) => {
+const ErrorModal = ({ errorMsg, errorStatus }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
-    if (error) {
-      setModalVisible(true);
-    }
-  }, [error]);
+    if (errorStatus) setModalVisible(true);
+    else setModalVisible(false);
+  }, [errorStatus]);
 
   return (
     <Modal
@@ -38,9 +37,7 @@ const ErrorModal = ({ error }) => {
         </ModalHeader>
 
         <ModalContent>
-          <ModalContentText>
-            {error?.data?.message ? error.data.message : ""}
-          </ModalContentText>
+          <ModalContentText>{errorMsg ? errorMsg : ""}</ModalContentText>
         </ModalContent>
 
         <ModalCloseButton

--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -12,7 +12,7 @@ import {
   ModalWrapper,
 } from "./styles";
 
-const ErrorModal = ({ errorMsg, errorStatus }) => {
+const ErrorModal = ({ errorMsg, errorStatus, setDataError }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
@@ -25,9 +25,25 @@ const ErrorModal = ({ errorMsg, errorStatus }) => {
       animationType="none"
       transparent={true}
       visible={modalVisible}
-      onRequestClose={() => setModalVisible(!modalVisible)}
+      onRequestClose={() => {
+        setDataError({
+          error: false,
+          message: "",
+        });
+
+        setModalVisible(!modalVisible);
+      }}
     >
-      <Pressable onPress={() => setModalVisible(!modalVisible)}>
+      <Pressable
+        onPress={() => {
+          setDataError({
+            error: false,
+            message: "",
+          });
+
+          setModalVisible(!modalVisible);
+        }}
+      >
         <ModalOverlay></ModalOverlay>
       </Pressable>
 
@@ -44,7 +60,14 @@ const ErrorModal = ({ errorMsg, errorStatus }) => {
           style={({ pressed }) => ({
             backgroundColor: pressed ? "#c6c6d1" : "white",
           })}
-          onPress={() => setModalVisible(!modalVisible)}
+          onPress={() => {
+            setDataError({
+              error: false,
+              message: "",
+            });
+
+            setModalVisible(!modalVisible);
+          }}
         >
           <ModalCloseButtonText>Close</ModalCloseButtonText>
         </ModalCloseButton>

--- a/covid-mapper/commons/components/ErrorModal/ErrorModal.js
+++ b/covid-mapper/commons/components/ErrorModal/ErrorModal.js
@@ -12,7 +12,7 @@ import {
   ModalWrapper,
 } from "./styles";
 
-const ErrorModal = ({ errorMsg, errorStatus, setDataError }) => {
+const ErrorModal = ({ errorMsg, errorStatus }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
@@ -25,25 +25,9 @@ const ErrorModal = ({ errorMsg, errorStatus, setDataError }) => {
       animationType="none"
       transparent={true}
       visible={modalVisible}
-      onRequestClose={() => {
-        setDataError({
-          error: false,
-          message: "",
-        });
-
-        setModalVisible(!modalVisible);
-      }}
+      onRequestClose={() => setModalVisible(!modalVisible)}
     >
-      <Pressable
-        onPress={() => {
-          setDataError({
-            error: false,
-            message: "",
-          });
-
-          setModalVisible(!modalVisible);
-        }}
-      >
+      <Pressable onPress={() => setModalVisible(!modalVisible)}>
         <ModalOverlay></ModalOverlay>
       </Pressable>
 
@@ -60,14 +44,7 @@ const ErrorModal = ({ errorMsg, errorStatus, setDataError }) => {
           style={({ pressed }) => ({
             backgroundColor: pressed ? "#c6c6d1" : "white",
           })}
-          onPress={() => {
-            setDataError({
-              error: false,
-              message: "",
-            });
-
-            setModalVisible(!modalVisible);
-          }}
+          onPress={() => setModalVisible(!modalVisible)}
         >
           <ModalCloseButtonText>Close</ModalCloseButtonText>
         </ModalCloseButton>

--- a/covid-mapper/commons/components/ErrorModal/styles.js
+++ b/covid-mapper/commons/components/ErrorModal/styles.js
@@ -1,3 +1,5 @@
+import styled from "styled-components/native";
+
 export const ModalOverlay = styled.View`
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
@@ -38,7 +40,7 @@ export const ModalContentText = styled.Text`
   font-size: 16px;
 `;
 
-export const ModalCloseButton = styled(Pressable)`
+export const ModalCloseButton = styled.Pressable`
   justify-content: center;
   align-items: center;
   width: 95%;

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -105,6 +105,7 @@ const USSearchMapLayout = () => {
 
   const handleSearchSubmit = (inputValue) => {
     // If there are no inputs for this, then it is the initial start.
+    refetchUSCounties();
     if (!searchUSState.length && !searchUSCounty.length) {
       setSearchUSState(inputValue);
       // setPrevPlaceholder(searchPlaceholder);
@@ -142,39 +143,40 @@ const USSearchMapLayout = () => {
 
   // To render to the slider if the user entered a US State.
   useEffect(() => {
-    if (searchUSState.length && usCountiesData) {
-      const centeredRegion = centroidRegion(
-        "united_states",
-        searchUSState,
-        mapRegion,
-        mapviewWidth,
-        mapviewHeight
-      );
+    if (searchUSState.length) {
+      if (usCountiesError) {
+        setDataError({
+          error: true,
+          message: usCountiesError.data.message,
+        });
 
-      setPrevPlaceholder(searchPlaceholder);
-      setSearchPlaceholder("Search by county");
+        setSearchUSState("");
+        // refetchUSCounties();
+      } else if (!usCountiesError && usCountiesData) {
+        const centeredRegion = centroidRegion(
+          "united_states",
+          searchUSState,
+          mapRegion,
+          mapviewWidth,
+          mapviewHeight
+        );
 
-      setMapRegion(centeredRegion);
-      setPrevRegion(centeredRegion);
+        setPrevPlaceholder(searchPlaceholder);
+        setSearchPlaceholder("Search by county");
 
-      setSliderData(usCountiesData);
-      setSliderDataLoading(usCountiesLoading);
+        setMapRegion(centeredRegion);
+        setPrevRegion(centeredRegion);
 
-      setSliderHeader(`${searchUSState} Data`);
+        setSliderData(usCountiesData);
+        setSliderDataLoading(usCountiesLoading);
 
-      refetchUSCounties();
-    } else if (searchUSState.length && usCountiesError) {
-      setDataError({
-        error: true,
-        message: usCountiesError.data.message,
-      });
+        setSliderHeader(`${searchUSState} Data`);
 
-      setSearchUSState("");
-      refetchUSCounties();
+        // refetchUSCounties();
+      }
     }
   }, [searchUSState, usCountiesData, usCountiesError]);
-  console.log("hello: ", searchUSState, searchUSCounty);
-  console.log("usCountiesError: ", usCountiesError);
+  console.log("loading: ", usCountiesLoading);
 
   // useEffect(() => {
   //   if (searchUSState.length && usCountiesError)
@@ -260,7 +262,7 @@ const USSearchMapLayout = () => {
       )}
 
       <BottomSheetModalProvider>
-        {!dataError.error && (
+        {!dataError.error && sliderData && (
           <PopupSlider
             setSliderButton={setSliderButton}
             sliderData={sliderData}

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useRef,
-  useCallback,
-  useMemo,
-} from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import * as Location from "expo-location";
 import {
   useWindowDimensions,
@@ -109,9 +103,8 @@ const USSearchMapLayout = () => {
     // If there are no inputs for this, then it is the initial start.
     if (!searchUSState.length && !searchUSCounty.length) {
       refetchUSCounties();
+
       setSearchUSState(inputValue);
-      // setPrevPlaceholder(searchPlaceholder);
-      // setSearchPlaceholder("Search by county");
     } else {
       setSearchUSCounty(inputValue);
     }
@@ -153,7 +146,6 @@ const USSearchMapLayout = () => {
         });
 
         setSearchUSState("");
-        // refetchUSCounties();
       } else if (usCountiesSuccess) {
         const centeredRegion = centroidRegion(
           "united_states",
@@ -173,24 +165,9 @@ const USSearchMapLayout = () => {
         setSliderDataLoading(usCountiesLoading);
 
         setSliderHeader(`${searchUSState} Data`);
-
-        // refetchUSCounties();
       }
     }
   }, [searchUSState, usCountiesError, usCountiesFetching, usCountiesSuccess]);
-
-  // useEffect(() => {
-  //   if (searchUSState.length && usCountiesError)
-  //     setDataError({
-  //       error: true,
-  //       message: usCountiesError.data.message,
-  //     });
-  //   else
-  //     setDataError({
-  //       error: false,
-  //       message: "",
-  //     });
-  // }, [searchUSState, usCountiesError]);
 
   // To render to the slider if the user entered a US County.
   useEffect(() => {

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -18,6 +18,7 @@ import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
 import { useGetAllUSCountiesFromStateQuery } from "../../api/covidApi";
+import { ErrorModal } from "../../commons/components/ErrorModal";
 import FloatingSearchButton from "../../commons/components/FloatingSearchButton/FloatingSearchButton";
 import { PreviousRegionButton } from "../../commons/components/PreviousRegionButton";
 import { centroidRegion, retrieveCountyData } from "../../utils";
@@ -40,7 +41,10 @@ const USSearchMapLayout = () => {
 
   const [sliderData, setSliderData] = useState(null);
   const [sliderDataLoading, setSliderDataLoading] = useState(null);
-  const [sliderDataError, setSliderDataError] = useState(null);
+  const [dataError, setDataError] = useState({
+    error: false,
+    message: "",
+  });
   const [sliderHeader, setSliderHeader] = useState("World Data");
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
@@ -150,7 +154,6 @@ const USSearchMapLayout = () => {
       setPrevRegion(centeredRegion);
 
       setSliderData(usCountiesData);
-      setSliderDataError(usCountiesError);
       setSliderDataLoading(usCountiesLoading);
 
       setSliderHeader(`${searchUSState} Data`);
@@ -159,11 +162,23 @@ const USSearchMapLayout = () => {
     }
   }, [searchUSState, usCountiesData]);
 
+  useEffect(() => {
+    if (searchUSState.length && usCountiesError)
+      setDataError({
+        error: true,
+        message: usCountiesError.data.message,
+      });
+    else
+      setDataError({
+        error: false,
+        message: "",
+      });
+  }, [searchUSState, usCountiesError]);
+
   // To render to the slider if the user entered a US County.
   useEffect(() => {
     if (searchUSCounty.length && usCountiesData) {
       setSliderData(retrieveCountyData(searchUSCounty, usCountiesData));
-      setSliderDataError(usCountiesError);
       setSliderDataLoading(usCountiesLoading);
 
       setSliderHeader(`${searchUSCounty} Data`);
@@ -172,6 +187,13 @@ const USSearchMapLayout = () => {
 
   return (
     <>
+      {dataError.error && (
+        <ErrorModal
+          errorMsg={dataError.message}
+          errorStatus={dataError.error}
+        />
+      )}
+
       <FloatingSearchButton
         pressHandler={() => {
           setSearchBarActive(!searchBarActive);

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -217,6 +217,7 @@ const USSearchMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
+          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -223,8 +223,7 @@ const USSearchMapLayout = () => {
         <></>
       )}
 
-      {/* This button should only be "connected" to states in the US */}
-      {!searchUSState.length > 0 ? null : (
+      {dataError.error && !searchUSState.length && (
         <PreviousRegionButton
           previousMapRegion={prevRegion}
           previousRegionTitle="state"
@@ -246,12 +245,14 @@ const USSearchMapLayout = () => {
       )}
 
       <BottomSheetModalProvider>
-        <PopupSlider
-          setSliderButton={setSliderButton}
-          sliderData={sliderData}
-          sliderHeader={sliderHeader}
-          bottomSheetModalRef={bottomSheetModalRef}
-        />
+        {!dataError.error && (
+          <PopupSlider
+            setSliderButton={setSliderButton}
+            sliderData={sliderData}
+            sliderHeader={sliderHeader}
+            bottomSheetModalRef={bottomSheetModalRef}
+          />
+        )}
 
         <Pressable onPressOut={Keyboard.dismiss}>
           <MapComponent

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -100,15 +100,18 @@ const USSearchMapLayout = () => {
   const [sliderButton, setSliderButton] = useState(true);
 
   const handleSearchSubmit = (inputValue) => {
-    // If there are no inputs for State, then it is the initial start.
-    if (!searchUSState.length && !searchUSCounty.length) {
-      // Refetch belongs here since the States data should be refetched. The County data
-      // would be extracted out of the States data, and so no refetch after the else block.
-      refetchUSCounties();
+    // There must be a input longer than 0 characters.
+    if (inputValue.length) {
+      // If there are no inputs for State, then it is the initial start.
+      if (!searchUSState.length && !searchUSCounty.length) {
+        // Refetch belongs here since the States data should be refetched. The County data
+        // would be extracted out of the States data, and so no refetch after the else block.
+        refetchUSCounties();
 
-      setSearchUSState(inputValue);
-    } else {
-      setSearchUSCounty(inputValue);
+        setSearchUSState(inputValue);
+      } else {
+        setSearchUSCounty(inputValue);
+      }
     }
   };
 

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -178,10 +178,22 @@ const USSearchMapLayout = () => {
   // To render to the slider if the user entered a US County.
   useEffect(() => {
     if (searchUSCounty.length && usCountiesData) {
-      setSliderData(retrieveCountyData(searchUSCounty, usCountiesData));
-      setSliderDataLoading(usCountiesLoading);
+      const selectedCountyData = retrieveCountyData(
+        searchUSCounty,
+        usCountiesData
+      );
 
-      setSliderHeader(`${searchUSCounty} Data`);
+      if (!selectedCountyData) {
+        setDataError({
+          error: true,
+          message: "County not found or doesn't have any historical data",
+        });
+      } else {
+        setSliderData(selectedCountyData);
+        setSliderDataLoading(usCountiesLoading);
+
+        setSliderHeader(`${searchUSCounty} Data`);
+      }
     }
   }, [searchUSCounty, usCountiesData]);
 

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -203,6 +203,7 @@ const USSearchMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
+          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -65,6 +65,8 @@ const USSearchMapLayout = () => {
   const {
     data: usCountiesData,
     isLoading: usCountiesLoading,
+    isFetching: usCountiesFetching,
+    isSuccess: usCountiesSuccess,
     error: usCountiesError,
     refetch: refetchUSCounties,
   } = useGetAllUSCountiesFromStateQuery(searchUSState);
@@ -105,8 +107,8 @@ const USSearchMapLayout = () => {
 
   const handleSearchSubmit = (inputValue) => {
     // If there are no inputs for this, then it is the initial start.
-    refetchUSCounties();
     if (!searchUSState.length && !searchUSCounty.length) {
+      refetchUSCounties();
       setSearchUSState(inputValue);
       // setPrevPlaceholder(searchPlaceholder);
       // setSearchPlaceholder("Search by county");
@@ -143,7 +145,7 @@ const USSearchMapLayout = () => {
 
   // To render to the slider if the user entered a US State.
   useEffect(() => {
-    if (searchUSState.length) {
+    if (searchUSState.length && !usCountiesFetching) {
       if (usCountiesError) {
         setDataError({
           error: true,
@@ -152,7 +154,7 @@ const USSearchMapLayout = () => {
 
         setSearchUSState("");
         // refetchUSCounties();
-      } else if (!usCountiesError && usCountiesData) {
+      } else if (usCountiesSuccess) {
         const centeredRegion = centroidRegion(
           "united_states",
           searchUSState,
@@ -175,8 +177,7 @@ const USSearchMapLayout = () => {
         // refetchUSCounties();
       }
     }
-  }, [searchUSState, usCountiesData, usCountiesError]);
-  console.log("loading: ", usCountiesLoading);
+  }, [searchUSState, usCountiesError, usCountiesFetching, usCountiesSuccess]);
 
   // useEffect(() => {
   //   if (searchUSState.length && usCountiesError)

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -107,8 +107,8 @@ const USSearchMapLayout = () => {
     // If there are no inputs for this, then it is the initial start.
     if (!searchUSState.length && !searchUSCounty.length) {
       setSearchUSState(inputValue);
-      setPrevPlaceholder(searchPlaceholder);
-      setSearchPlaceholder("Search by county");
+      // setPrevPlaceholder(searchPlaceholder);
+      // setSearchPlaceholder("Search by county");
     } else {
       setSearchUSCounty(inputValue);
     }
@@ -151,6 +151,9 @@ const USSearchMapLayout = () => {
         mapviewHeight
       );
 
+      setPrevPlaceholder(searchPlaceholder);
+      setSearchPlaceholder("Search by county");
+
       setMapRegion(centeredRegion);
       setPrevRegion(centeredRegion);
 
@@ -160,21 +163,31 @@ const USSearchMapLayout = () => {
       setSliderHeader(`${searchUSState} Data`);
 
       refetchUSCounties();
-    }
-  }, [searchUSState, usCountiesData]);
-
-  useEffect(() => {
-    if (searchUSState.length && usCountiesError)
+    } else if (searchUSState.length && usCountiesError) {
       setDataError({
         error: true,
         message: usCountiesError.data.message,
       });
-    else
-      setDataError({
-        error: false,
-        message: "",
-      });
-  }, [searchUSState, usCountiesError]);
+
+      setSearchUSState("");
+      refetchUSCounties();
+    }
+  }, [searchUSState, usCountiesData, usCountiesError]);
+  console.log("hello: ", searchUSState, searchUSCounty);
+  console.log("usCountiesError: ", usCountiesError);
+
+  // useEffect(() => {
+  //   if (searchUSState.length && usCountiesError)
+  //     setDataError({
+  //       error: true,
+  //       message: usCountiesError.data.message,
+  //     });
+  //   else
+  //     setDataError({
+  //       error: false,
+  //       message: "",
+  //     });
+  // }, [searchUSState, usCountiesError]);
 
   // To render to the slider if the user entered a US County.
   useEffect(() => {

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -100,8 +100,10 @@ const USSearchMapLayout = () => {
   const [sliderButton, setSliderButton] = useState(true);
 
   const handleSearchSubmit = (inputValue) => {
-    // If there are no inputs for this, then it is the initial start.
+    // If there are no inputs for State, then it is the initial start.
     if (!searchUSState.length && !searchUSCounty.length) {
+      // Refetch belongs here since the States data should be refetched. The County data
+      // would be extracted out of the States data, and so no refetch after the else block.
       refetchUSCounties();
 
       setSearchUSState(inputValue);
@@ -138,15 +140,22 @@ const USSearchMapLayout = () => {
 
   // To render to the slider if the user entered a US State.
   useEffect(() => {
+    // First check if the user has entered a State and if the data is not being fetched.
     if (searchUSState.length && !usCountiesFetching) {
+      // After the fetch, check to see first if there are errors from the API.
       if (usCountiesError) {
         setDataError({
           error: true,
           message: usCountiesError.data.message,
         });
 
+        // Reset the searchState to an empty string. This is the case if the user entered
+        // the wrong name of the State.
         setSearchUSState("");
+
+        // Check to see if the API call was a success.
       } else if (usCountiesSuccess) {
+        // Get the centered region.
         const centeredRegion = centroidRegion(
           "united_states",
           searchUSState,
@@ -155,15 +164,20 @@ const USSearchMapLayout = () => {
           mapviewHeight
         );
 
+        // Update the placeholder and store the previous placeholder in case the user
+        // reverts back to selecting a State.
         setPrevPlaceholder(searchPlaceholder);
         setSearchPlaceholder("Search by county");
 
+        // Set the centered region.
         setMapRegion(centeredRegion);
         setPrevRegion(centeredRegion);
 
+        // Update the slider data to be displayed.
         setSliderData(usCountiesData);
         setSliderDataLoading(usCountiesLoading);
 
+        // Update the slider header to display the user's selected State.
         setSliderHeader(`${searchUSState} Data`);
       }
     }
@@ -171,12 +185,17 @@ const USSearchMapLayout = () => {
 
   // To render to the slider if the user entered a US County.
   useEffect(() => {
+    // First check if the user has entered a County and if the API data exists so that
+    // the County could be extracted from it (don't want to extract from NULL).
     if (searchUSCounty.length && usCountiesData) {
+      // Extract the selected county, if it exists.
       const selectedCountyData = retrieveCountyData(
         searchUSCounty,
         usCountiesData
       );
 
+      // If the extracted selected county does not exist, let the user know what they
+      // typed is incorrect.
       if (!selectedCountyData) {
         setDataError({
           error: true,

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -204,7 +204,6 @@ const USSearchMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
-          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -45,6 +45,7 @@ const USSearchMapLayout = () => {
     error: false,
     message: "",
   });
+
   const [sliderHeader, setSliderHeader] = useState("World Data");
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
@@ -224,7 +225,7 @@ const USSearchMapLayout = () => {
         <></>
       )}
 
-      {dataError.error && !searchUSState.length && (
+      {searchUSState.length > 0 && !dataError.error && (
         <PreviousRegionButton
           previousMapRegion={prevRegion}
           previousRegionTitle="state"

--- a/covid-mapper/features/map-layout/USViewMapLayout.js
+++ b/covid-mapper/features/map-layout/USViewMapLayout.js
@@ -120,7 +120,6 @@ const USViewMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
-          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/USViewMapLayout.js
+++ b/covid-mapper/features/map-layout/USViewMapLayout.js
@@ -12,6 +12,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { PopupSliderButton, PopupSlider } from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import { useGetTotalsAllStatesUSQuery } from "../../api/covidApi";
+import { ErrorModal } from "../../commons/components/ErrorModal";
 
 const USViewMapLayout = () => {
   const {
@@ -25,7 +26,10 @@ const USViewMapLayout = () => {
 
   const [sliderData, setSliderData] = useState(null);
   const [sliderDataLoading, setSliderDataLoading] = useState(null);
-  const [sliderDataError, setSliderDataError] = useState(null);
+  const [dataError, setDataError] = useState({
+    error: false,
+    message: "",
+  });
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
 
@@ -63,9 +67,21 @@ const USViewMapLayout = () => {
     if (allUSStatesData) {
       setSliderData(allUSStatesData);
       setSliderDataLoading(allUSStatesLoading);
-      setSliderDataError(allUSStatesError);
     }
   }, [allUSStatesData]);
+
+  useEffect(() => {
+    if (allUSStatesError)
+      setDataError({
+        error: true,
+        message: allUSStatesError.data.message,
+      });
+    else
+      setDataError({
+        error: false,
+        message: "",
+      });
+  }, [allUSStatesError]);
 
   // To open the slider once data has been loaded
   useEffect(() => {
@@ -100,6 +116,13 @@ const USViewMapLayout = () => {
 
   return (
     <>
+      {dataError.error && (
+        <ErrorModal
+          errorMsg={dataError.message}
+          errorStatus={dataError.error}
+        />
+      )}
+
       {sliderData && sliderButton && (
         <PopupSliderButton
           handlePresentModalPress={handlePresentModalPress}

--- a/covid-mapper/features/map-layout/USViewMapLayout.js
+++ b/covid-mapper/features/map-layout/USViewMapLayout.js
@@ -120,6 +120,7 @@ const USViewMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
+          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -234,7 +234,6 @@ const WorldSearchMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
-          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -234,6 +234,7 @@ const WorldSearchMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
+          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/WorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldViewMapLayout.js
@@ -12,6 +12,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import { useGetGlobalCovidStatsQuery } from "../../api/covidApi";
+import { ErrorModal } from "./../../commons/components/ErrorModal";
 
 const WorldMapLayout = () => {
   const {
@@ -25,7 +26,10 @@ const WorldMapLayout = () => {
 
   const [sliderData, setSliderData] = useState(null);
   const [sliderDataLoading, setSliderDataLoading] = useState(null);
-  const [sliderDataError, setSliderDataError] = useState(null);
+  const [dataError, setDataError] = useState({
+    error: false,
+    message: "",
+  });
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
 
@@ -63,9 +67,21 @@ const WorldMapLayout = () => {
     if (globalCovidStatsData) {
       setSliderData(globalCovidStatsData);
       setSliderDataLoading(globalCovidStatsLoading);
-      setSliderDataError(globalCovidStatsError);
     }
   }, [globalCovidStatsData]);
+
+  useEffect(() => {
+    if (globalCovidStatsError)
+      setDataError({
+        error: true,
+        message: globalCovidStatsError.data.message,
+      });
+    else
+      setDataError({
+        error: false,
+        message: "",
+      });
+  }, [globalCovidStatsError]);
 
   // To open the slider once data has been loaded
   useEffect(() => {
@@ -100,6 +116,13 @@ const WorldMapLayout = () => {
 
   return (
     <>
+      {dataError.error && (
+        <ErrorModal
+          errorMsg={dataError.message}
+          errorStatus={dataError.error}
+        />
+      )}
+
       {sliderData && sliderButton && (
         <PopupSliderButton
           handlePresentModalPress={handlePresentModalPress}

--- a/covid-mapper/features/map-layout/WorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldViewMapLayout.js
@@ -120,6 +120,7 @@ const WorldMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
+          setDataError={setDataError}
         />
       )}
 

--- a/covid-mapper/features/map-layout/WorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldViewMapLayout.js
@@ -120,7 +120,6 @@ const WorldMapLayout = () => {
         <ErrorModal
           errorMsg={dataError.message}
           errorStatus={dataError.error}
-          setDataError={setDataError}
         />
       )}
 


### PR DESCRIPTION
## Changes
1. Added a `setDataError` prop in Error Modal to reset the errors, and rendered the Error Modal in all the layouts with conditionals.
2. Changed the placement of the placeholder states to run only when the data being fetched is a success and not an error.
3. Moved the `refetch` query hook function to run on user submission and not in the `useEffect`.
4. Imported the `success` and `fetching` query properties, and used it in the `useEffect` to make better conditionals instead of relying if the data has been fetched.

## Purpose
When an API is fetched, the Error Modal should appear on the screen if there are any errors, and if there is an error from the API on the country/states, the user should not be able to proceed on searching provinces/county.

## Approach
The approach was mainly on making the error side work for the layouts. To do this was first expanding the Error Modal component where it takes in the `setDataError` prop so that when the user hits the close button or click outside the modal, the `dataError` would reset. This was done so that it could keep updating itself whenever there is an error for the API, and to display that error instead of holding onto the previous error.

Another approach was to change the placement of the placeholder states. Currently, it is inside the handle submit function where it would automatically update when the user submits. But, the issue with this is that if there are any API errors, the placeholder should not change. To fix this was to put the placeholder states inside the `useEffect` and only run when there is a success on the data.

Another minor bug fix was to move the `refetch` outside of the `useEffect` and into the handle submit function since `refetch` has the `useEffect` built-in.

The last part was restructuring the logic for the `useEffects` in searching by country/province or by state/county. The reason for this is that before the slider could receive the API data, it needs to wait until the API is done fetching. Once it is done, it checks first if there are any errors, and if there are then display that error and don't let the slider retrieve the API data. If the API was a success after fetching, then let the slider have the data.

Closes #144 
Closes #152