### PR TITLE
Set county coordinate marker on Map

### DIFF
--- a/covid-mapper/api/covidApi.js
+++ b/covid-mapper/api/covidApi.js
@@ -173,6 +173,27 @@ export const covidApi = createApi({
           population: response.population ?? 0,
         })),
     }),
+    getUSCountyCoordinates: builder.query({
+      query: (county) => {
+        const endpoint = !county
+          ? "not-chosen"
+          : !county.length
+          ? "not-chosen"
+          : county.toLowerCase();
+        return `jhucsse/counties/${endpoint}`;
+      },
+      transformResponse: (response) =>
+        response.map((countyObj) => {
+          const { province, coordinates, county, updatedAt, stats } = countyObj;
+          return {
+            state: province,
+            county,
+            coordinates,
+            updatedAt,
+            stats
+          };
+        }),
+    }),
 
     // VACCINES
     getVaccinesTrialData: builder.query({
@@ -204,6 +225,7 @@ export const {
   useGetTotalOneUSStateQuery,
   useGetAllCountriesProvincesHistoricalQuery,
   useGetAllUSCountiesFromStateQuery,
+  useGetUSCountyCoordinatesQuery,
   useGetCountryHistoricalQuery,
   useGetCountriesHistoricalQuery,
   useGetProvinceHistoricalQuery,

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -71,9 +71,7 @@ const USSearchMapLayout = () => {
     isLoading: countyCoordinatesLoading,
     isSuccess: countyCooordinatesSuccess,
     error: countyCoordinatesError
-  } = useGetUSCountyCoordinatesQuery(searchUSCounty)
-
-  console.log('COUNTY COORDS: ', countyCoordinatesData)
+  } = useGetUSCountyCoordinatesQuery(searchUSCounty);
 
   const [mapRegion, setMapRegion] = useState({
     latitude: 36.778259,
@@ -196,6 +194,27 @@ const USSearchMapLayout = () => {
     }
   }, [searchUSState, usCountiesError, usCountiesFetching, usCountiesSuccess]);
 
+  useEffect(()=>{
+    if(countyCoordinatesData){
+      /*
+       Filter out the county object whose "state" property value matches searchUSState:
+        Example: California and New York both have a "Kings county". This filters the county(in the right US state) user searched for.
+      */
+      const targetCountyObj = countyCoordinatesData.filter(countyObj=>countyObj.state===searchUSState)[0];
+      
+      // object with latitude and longtitude properties(stirngs)
+      const {coordinates} = targetCountyObj;
+      const {latitude, longitude}=coordinates;
+      
+      setMapRegion({
+        latitude: parseInt(latitude),
+        longitude: parseInt(longitude),
+        latitudeDelta: 1.0922,
+        longitudeDelta: 1.0421,
+      });
+    }
+  },[countyCoordinatesData])
+
   // To render to the slider if the user entered a US County.
   useEffect(() => {
     // First check if the user has entered a County and if the API data exists so that
@@ -222,13 +241,6 @@ const USSearchMapLayout = () => {
       }
     }
   }, [searchUSCounty, usCountiesData]);
-
-  useEffect(()=>{
-    if(countyCoordinatesData){
-      // Filter out the county object whose "state" value matches searchUSState
-      const targetCountyObj = countyCoordinatesData.filter(countyObj=>countyObj.state===searchUSState)[0];
-    }
-  },[countyCoordinatesData])
 
   return (
     <>

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -17,7 +17,7 @@ import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
-import { useGetAllUSCountiesFromStateQuery } from "../../api/covidApi";
+import { useGetAllUSCountiesFromStateQuery, useGetUSCountyCoordinatesQuery } from "../../api/covidApi";
 import FloatingSearchButton from "../../commons/components/FloatingSearchButton/FloatingSearchButton";
 import { PreviousRegionButton } from "../../commons/components/PreviousRegionButton";
 import { centroidRegion, retrieveCountyData } from "../../utils";
@@ -63,6 +63,16 @@ const USSearchMapLayout = () => {
     error: usCountiesError,
     refetch: refetchUSCounties,
   } = useGetAllUSCountiesFromStateQuery(searchUSState);
+
+  // For obtaininig array of counties object, with "coordinates" & "state"(string; in case of different states having counties with same name)
+  const {
+    data: countyCoordinatesData,
+    isLoading: countyCoordinatesLoading,
+    isSuccess: countyCooordinatesSuccess,
+    error: countyCoordinatesError
+  } = useGetUSCountyCoordinatesQuery(searchUSCounty)
+
+  console.log('COUNTY COORDS: ', countyCoordinatesData)
 
   const [mapRegion, setMapRegion] = useState({
     latitude: 36.778259,
@@ -145,7 +155,7 @@ const USSearchMapLayout = () => {
         mapviewWidth,
         mapviewHeight
       );
-
+  
       setMapRegion(centeredRegion);
       setPrevRegion(centeredRegion);
 
@@ -169,6 +179,13 @@ const USSearchMapLayout = () => {
       setSliderHeader(`${searchUSCounty} Data`);
     }
   }, [searchUSCounty, usCountiesData]);
+
+  useEffect(()=>{
+    if(countyCoordinatesData){
+      // Filter out the county object whose "state" value matches searchUSState
+      const targetCountyObj = countyCoordinatesData.filter(countyObj=>countyObj.state===searchUSState)[0];
+    }
+  },[countyCoordinatesData])
 
   return (
     <>


### PR DESCRIPTION
## Changes
1. Added redux toolkit query hook to fetch US county coordinates.
2. Invoke `setMapRegion` with a county's coordinates object as argument.

## Purpose
_Describe the problem or feature in addition to a link to the issues._

## Approach
RTK Query, hooks, filter(),  conditional.

Closes #140 