### PR TITLE
Fixed the loading Spinner when APIs are being fetched

### DIFF
--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -195,54 +195,52 @@ const USSearchMapLayout = () => {
   }, [searchUSState, usCountiesError, usCountiesFetching, usCountiesSuccess]);
 
   useEffect(() => {
-    if (countyCoordinatesData) {
-      /*
-       Filter out the county object whose "state" property value matches searchUSState:
-        Example: California and New York both have a "Kings county". This filters the county(in the right US state) user searched for.
-      */
-      const targetCountyObj = countyCoordinatesData.filter(
-        (countyObj) =>
-          countyObj.state.toLowerCase() === searchUSState.toLowerCase()
-      )[0];
-
-      // object with latitude and longtitude properties(stirngs)
-      const { coordinates } = targetCountyObj;
-      const { latitude, longitude } = coordinates;
-
-      setMapRegion({
-        latitude: parseInt(latitude),
-        longitude: parseInt(longitude),
-        latitudeDelta: 1.0922,
-        longitudeDelta: 1.0421,
-      });
-    }
-  }, [countyCoordinatesData]);
-
-  // To render to the slider if the user entered a US County.
-  useEffect(() => {
-    // First check if the user has entered a County and if the API data exists so that
-    // the County could be extracted from it (don't want to extract from NULL).
-    if (searchUSCounty.length && usCountiesData) {
-      // Extract the selected county, if it exists.
-      const selectedCountyData = retrieveCountyData(
-        searchUSCounty,
-        usCountiesData
-      );
-
-      // If the extracted selected county does not exist, let the user know what they
-      // typed is incorrect.
-      if (!selectedCountyData) {
+    if (searchUSCounty.length && !countyCoordinatesFetching) {
+      if (countyCoordinatesError) {
         setDataError({
           error: true,
-          message: "County not found or doesn't have any historical data",
+          message: countyCoordinatesError.data.message,
         });
-      } else {
+
+        setSearchUSCounty("");
+      } else if (countyCooordinatesSuccess) {
+        /*
+         Filter out the county object whose "state" property value matches searchUSState:
+          Example: California and New York both have a "Kings county". This filters the county(in the right US state) user searched for.
+        */
+        const targetCountyObj = countyCoordinatesData.filter(
+          (countyObj) =>
+            countyObj.state.toLowerCase() === searchUSState.toLowerCase()
+        )[0];
+
+        // object with latitude and longtitude properties(stirngs)
+        const { coordinates } = targetCountyObj;
+        const { latitude, longitude } = coordinates;
+
+        setMapRegion({
+          latitude: parseInt(latitude),
+          longitude: parseInt(longitude),
+          latitudeDelta: 1.0922,
+          longitudeDelta: 1.0421,
+        });
+
+        // Extract the selected county, if it exists.
+        const selectedCountyData = retrieveCountyData(
+          searchUSCounty,
+          usCountiesData
+        );
+
         setSliderData(selectedCountyData);
 
         setSliderHeader(`${searchUSCounty} Data`);
       }
     }
-  }, [searchUSCounty, usCountiesData]);
+  }, [
+    searchUSCounty,
+    countyCoordinatesError,
+    countyCoordinatesFetching,
+    countyCooordinatesSuccess,
+  ]);
 
   return (
     <>

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -34,7 +34,6 @@ const USSearchMapLayout = () => {
   const [errorMsg, setErrorMsg] = useState(null);
 
   const [sliderData, setSliderData] = useState(null);
-  const [sliderDataLoading, setSliderDataLoading] = useState(null);
   const [dataError, setDataError] = useState({
     error: false,
     message: "",
@@ -58,7 +57,6 @@ const USSearchMapLayout = () => {
 
   const {
     data: usCountiesData,
-    isLoading: usCountiesLoading,
     isFetching: usCountiesFetching,
     isSuccess: usCountiesSuccess,
     error: usCountiesError,
@@ -178,7 +176,6 @@ const USSearchMapLayout = () => {
 
         // Update the slider data to be displayed.
         setSliderData(usCountiesData);
-        setSliderDataLoading(usCountiesLoading);
 
         // Update the slider header to display the user's selected State.
         setSliderHeader(`${searchUSState} Data`);
@@ -206,7 +203,6 @@ const USSearchMapLayout = () => {
         });
       } else {
         setSliderData(selectedCountyData);
-        setSliderDataLoading(usCountiesLoading);
 
         setSliderHeader(`${searchUSCounty} Data`);
       }

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -231,6 +231,7 @@ const USSearchMapLayout = () => {
       ></FloatingSearchButton>
       {searchBarActive ? (
         <Searchbar
+          dataLoading={usCountiesFetching}
           handleSearchSubmit={handleSearchSubmit}
           searchPlaceholder={searchPlaceholder}
           opacityLevel={fadeAnim}
@@ -240,7 +241,7 @@ const USSearchMapLayout = () => {
         <></>
       )}
 
-      {searchUSState.length > 0 && !dataError.error && (
+      {!usCountiesFetching && searchUSState.length > 0 && !dataError.error && (
         <PreviousRegionButton
           previousMapRegion={prevRegion}
           previousRegionTitle="state"
@@ -254,7 +255,7 @@ const USSearchMapLayout = () => {
         />
       )}
 
-      {!sliderData ? null : !sliderButton ? null : (
+      {usCountiesFetching ? null : !sliderData ? null : !sliderButton ? null : (
         <PopupSliderButton
           handlePresentModalPress={handlePresentModalPress}
           setSliderButton={setSliderButton}
@@ -262,7 +263,7 @@ const USSearchMapLayout = () => {
       )}
 
       <BottomSheetModalProvider>
-        {!dataError.error && sliderData && (
+        {!usCountiesFetching && !dataError.error && sliderData && (
           <PopupSlider
             setSliderButton={setSliderButton}
             sliderData={sliderData}

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -201,7 +201,8 @@ const USSearchMapLayout = () => {
         Example: California and New York both have a "Kings county". This filters the county(in the right US state) user searched for.
       */
       const targetCountyObj = countyCoordinatesData.filter(
-        (countyObj) => countyObj.state === searchUSState
+        (countyObj) =>
+          countyObj.state.toLowerCase() === searchUSState.toLowerCase()
       )[0];
 
       // object with latitude and longtitude properties(stirngs)

--- a/covid-mapper/features/map-layout/USViewMapLayout.js
+++ b/covid-mapper/features/map-layout/USViewMapLayout.js
@@ -15,17 +15,13 @@ import { useGetTotalsAllStatesUSQuery } from "../../api/covidApi";
 import { ErrorModal } from "../../commons/components/ErrorModal";
 
 const USViewMapLayout = () => {
-  const {
-    data: allUSStatesData,
-    isLoading: allUSStatesLoading,
-    error: allUSStatesError,
-  } = useGetTotalsAllStatesUSQuery();
+  const { data: allUSStatesData, error: allUSStatesError } =
+    useGetTotalsAllStatesUSQuery();
 
   const [userLocation, setUserLocation] = useState(null);
   const [errorMsg, setErrorMsg] = useState(null);
 
   const [sliderData, setSliderData] = useState(null);
-  const [sliderDataLoading, setSliderDataLoading] = useState(null);
   const [dataError, setDataError] = useState({
     error: false,
     message: "",
@@ -66,7 +62,6 @@ const USViewMapLayout = () => {
   useEffect(() => {
     if (allUSStatesData) {
       setSliderData(allUSStatesData);
-      setSliderDataLoading(allUSStatesLoading);
     }
   }, [allUSStatesData]);
 

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -37,7 +37,6 @@ const WorldSearchMapLayout = () => {
   const [errorMsg, setErrorMsg] = useState(null);
 
   const [sliderData, setSliderData] = useState(null);
-  const [sliderDataLoading, setSliderDataLoading] = useState(null);
   const [dataError, setDataError] = useState({
     error: false,
     message: "",
@@ -60,7 +59,6 @@ const WorldSearchMapLayout = () => {
 
   const {
     data: countryHistoricalData,
-    isLoading: countryHistoricalLoading,
     isFetching: countryHistoricalFetching,
     isSuccess: countryHistoricalSuccess,
     error: countryHistoricalError,
@@ -68,7 +66,6 @@ const WorldSearchMapLayout = () => {
   } = useGetCountryHistoricalQuery(searchCountry);
   const {
     data: provinceHistoricalData,
-    isLoading: provinceHistoricalLoading,
     isFetching: provinceHistoricalFetching,
     isSuccess: provinceHistoricalSuccess,
     error: provinceHistoricalError,
@@ -197,7 +194,6 @@ const WorldSearchMapLayout = () => {
 
         // Update the slider data to be displayed.
         setSliderData(countryHistoricalData);
-        setSliderDataLoading(countryHistoricalLoading);
 
         // Update the slider header to display the user's selected Country.
         setSliderHeader(`${searchCountry} Data`);
@@ -232,7 +228,6 @@ const WorldSearchMapLayout = () => {
         );
 
         setSliderData(provinceHistoricalData);
-        setSliderDataLoading(provinceHistoricalLoading);
 
         setSliderHeader(`${searchProvince} Data`);
       }

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -138,7 +138,7 @@ const WorldSearchMapLayout = () => {
       let { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
         setErrorMsg("Permission to access location was denied");
-        
+
         setUserLocation(mapRegion);
         return;
       }
@@ -262,6 +262,9 @@ const WorldSearchMapLayout = () => {
       ></FloatingSearchButton>
       {searchBarActive ? (
         <Searchbar
+          dataLoading={
+            countryHistoricalFetching || provinceHistoricalFetching || false
+          }
           handleSearchSubmit={handleSearchSubmit}
           searchPlaceholder={searchPlaceholder}
           opacityLevel={fadeAnim}
@@ -271,21 +274,24 @@ const WorldSearchMapLayout = () => {
         <></>
       )}
 
-      {searchCountry.length > 0 && !dataError.error && (
-        <PreviousRegionButton
-          previousMapRegion={prevRegion}
-          previousRegionTitle="country"
-          previousSearchPlaceholder={prevPlaceholder}
-          searchLandmass={searchCountry}
-          searchSubLandmass={searchProvince}
-          setMapRegion={setMapRegion}
-          setSearchLandmass={setSearchCountry}
-          setSearchPlaceholder={setSearchPlaceholder}
-          setSearchSubLandmass={setSearchProvince}
-        />
-      )}
+      {!countryHistoricalFetching &&
+        !provinceHistoricalFetching &&
+        searchCountry.length > 0 &&
+        !dataError.error && (
+          <PreviousRegionButton
+            previousMapRegion={prevRegion}
+            previousRegionTitle="country"
+            previousSearchPlaceholder={prevPlaceholder}
+            searchLandmass={searchCountry}
+            searchSubLandmass={searchProvince}
+            setMapRegion={setMapRegion}
+            setSearchLandmass={setSearchCountry}
+            setSearchPlaceholder={setSearchPlaceholder}
+            setSearchSubLandmass={setSearchProvince}
+          />
+        )}
 
-      {!sliderData ? null : !sliderButton ? null : (
+      {countryHistoricalFetching ? null : provinceHistoricalFetching ? null : !sliderData ? null : !sliderButton ? null : (
         <PopupSliderButton
           handlePresentModalPress={handlePresentModalPress}
           setSliderButton={setSliderButton}
@@ -293,14 +299,17 @@ const WorldSearchMapLayout = () => {
       )}
 
       <BottomSheetModalProvider>
-        {!dataError.error && sliderData && (
-          <PopupSlider
-            setSliderButton={setSliderButton}
-            sliderData={sliderData}
-            sliderHeader={sliderHeader}
-            bottomSheetModalRef={bottomSheetModalRef}
-          />
-        )}
+        {!countryHistoricalFetching &&
+          !provinceHistoricalFetching &&
+          !dataError.error &&
+          sliderData && (
+            <PopupSlider
+              setSliderButton={setSliderButton}
+              sliderData={sliderData}
+              sliderHeader={sliderHeader}
+              bottomSheetModalRef={bottomSheetModalRef}
+            />
+          )}
 
         <Pressable onPressOut={Keyboard.dismiss}>
           <MapComponent

--- a/covid-mapper/features/map-layout/WorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldViewMapLayout.js
@@ -15,17 +15,13 @@ import { useGetGlobalCovidStatsQuery } from "../../api/covidApi";
 import { ErrorModal } from "./../../commons/components/ErrorModal";
 
 const WorldMapLayout = () => {
-  const {
-    data: globalCovidStatsData,
-    isLoading: globalCovidStatsLoading,
-    error: globalCovidStatsError,
-  } = useGetGlobalCovidStatsQuery();
+  const { data: globalCovidStatsData, error: globalCovidStatsError } =
+    useGetGlobalCovidStatsQuery();
 
   const [userLocation, setUserLocation] = useState(null);
   const [errorMsg, setErrorMsg] = useState(null);
 
   const [sliderData, setSliderData] = useState(null);
-  const [sliderDataLoading, setSliderDataLoading] = useState(null);
   const [dataError, setDataError] = useState({
     error: false,
     message: "",
@@ -66,7 +62,6 @@ const WorldMapLayout = () => {
   useEffect(() => {
     if (globalCovidStatsData) {
       setSliderData(globalCovidStatsData);
-      setSliderDataLoading(globalCovidStatsLoading);
     }
   }, [globalCovidStatsData]);
 

--- a/covid-mapper/features/searchbar/Searchbar.js
+++ b/covid-mapper/features/searchbar/Searchbar.js
@@ -28,7 +28,6 @@ const SearchbarInput = styled.TextInput`
   border-radius: 50px;
 `;
 
-
 const SearchbarSpinnerLoading = styled.View`
   position: absolute;
   right: 5%;
@@ -40,35 +39,31 @@ const Searchbar = ({
   opacityLevel,
   handlePresentModalPress,
   dataLoading,
-  searchOptionsAlertMessage
+  searchOptionsAlertMessage,
 }) => {
   const [searchInput, setSearchInput] = useState("");
   const [isFocus, setIsFocus] = useState(false);
   const [isSearchIconPressedIn, setIsSearchIconPressedIn] = useState(false);
-  
 
   // For later use: if searchOptions doesn't contain search input, render Alert
 
-        // Returns boolean for conditionally rendering Alert in Searchbar
-      let validSearchInput;
-      // if(searchOptionsAlertMessage.length>0){
-      //   validSearchInput = searchOptionsAlertMessage.some(region=>region===searchInput.toLowerCase())
-      // } 
+  // Returns boolean for conditionally rendering Alert in Searchbar
+  let validSearchInput;
+  // if(searchOptionsAlertMessage.length>0){
+  //   validSearchInput = searchOptionsAlertMessage.some(region=>region===searchInput.toLowerCase())
+  // }
 
-      // const CreateSearchOptionsAlert = ()=>Alert.alert( "What you could search for: \n\n",
-      // `${searchOptionsAlertMessage.map(region=><Text>{capitalize(region)+',\n'}</Text>)}`,
-      // [
-      //   {
-      //     text: "Cancel",
-      //   },
-      // ])
+  // const CreateSearchOptionsAlert = ()=>Alert.alert( "What you could search for: \n\n",
+  // `${searchOptionsAlertMessage.map(region=><Text>{capitalize(region)+',\n'}</Text>)}`,
+  // [
+  //   {
+  //     text: "Cancel",
+  //   },
+  // ])
 
-       
-      if(validSearchInput){
-        CreateSearchOptionsAlert();
-      }
-
-  
+  if (validSearchInput) {
+    CreateSearchOptionsAlert();
+  }
 
   return (
     <Animated.View
@@ -82,10 +77,13 @@ const Searchbar = ({
           onPressIn={() => setIsSearchIconPressedIn(true)}
           onPressOut={() => setIsSearchIconPressedIn(false)}
           onPress={() => {
-            handleSearchSubmit(searchInput);
-            setSearchInput("");
-            handlePresentModalPress();
-            Keyboard.dismiss();
+            // If the data is being fetched, don't let them submit anything.
+            if (!dataLoading) {
+              handleSearchSubmit(searchInput);
+              setSearchInput("");
+              handlePresentModalPress();
+              Keyboard.dismiss();
+            }
           }}
         >
           <SearchbarIcon
@@ -105,9 +103,12 @@ const Searchbar = ({
         onBlur={() => setIsFocus(!searchInput.length ? false : true)}
         onChangeText={(text) => setSearchInput(text)}
         onSubmitEditing={() => {
-          handleSearchSubmit(searchInput);
-          handlePresentModalPress();
-          setSearchInput("");
+          // If the data is being fetched, don't let them submit anything.
+          if (!dataLoading) {
+            handleSearchSubmit(searchInput);
+            handlePresentModalPress();
+            setSearchInput("");
+          }
         }}
       />
 


### PR DESCRIPTION
## Changes
1. Added the `fetch` query property to the Searchbar as a prop in order to render the Loading Spinner if the API is being fetched.
2. Added more conditional renderings with the `fetch` query property on some of the components to only appear when there are no API fetching.
3. Merged the `useEffect` for the `countyCoordinatesData` and the other `useEffect` for the `usCountiesData` since they are the same thing, and expanded on the merged `useEffect` to conditionally check on any errors or fetching.

## Purpose
When an API is being fetched, the loading Spinner should appear on the searchbar until the data/error returns.

Closes #143 