### PR TITLE
Displayed the Vaccine endpoints in the MapLayout

### DIFF
--- a/covid-mapper/api/covidApi.js
+++ b/covid-mapper/api/covidApi.js
@@ -16,6 +16,7 @@ export const covidApi = createApi({
         deaths: response.deaths,
         recovered: response.recovered,
         hasTimelineSequence: typeof response.cases === "number" ? false : true,
+        country: "",
         provinces: "",
         state: "",
         county: "",
@@ -43,6 +44,7 @@ export const covidApi = createApi({
           deaths: state.deaths,
           recovered: state.recovered ?? "No info",
           hasTimelineSequence: typeof state.cases === "number" ? false : true,
+          country: "",
           provinces: "",
           state: state.state,
           county: "",
@@ -66,6 +68,7 @@ export const covidApi = createApi({
         deaths: response.deaths,
         recovered: response.recovered,
         hasTimelineSequence: typeof response.cases === "number" ? false : true,
+        country: "",
         provinces: "",
         state: response.state,
         county: "",
@@ -82,6 +85,7 @@ export const covidApi = createApi({
         deaths: cartesianCoordinateConverter(response.deaths),
         recovered: cartesianCoordinateConverter(response.recovered),
         hasTimelineSequence: typeof response.cases === "number" ? false : true,
+        country: "",
         provinces: "",
         state: "",
         county: "",
@@ -104,6 +108,7 @@ export const covidApi = createApi({
         recovered: cartesianCoordinateConverter(response.timeline.recovered),
         hasTimelineSequence:
           typeof response.timeline.cases === "number" ? false : true,
+        country: "",
         provinces: response.province
           .map((val) => capitalize(val, true))
           .join(", "),
@@ -138,6 +143,7 @@ export const covidApi = createApi({
         recovered: cartesianCoordinateConverter(response.timeline.recovered),
         hasTimelineSequence:
           typeof response.timeline.cases === "number" ? false : true,
+        country: "",
         provinces: capitalize(response.province, true),
         state: "",
         county: "",
@@ -166,6 +172,7 @@ export const covidApi = createApi({
           recovered: cartesianCoordinateConverter(county.timeline.recovered),
           hasTimelineSequence:
             typeof county.timeline.cases === "number" ? false : true,
+          country: "",
           provinces: "",
           state: "",
           county: capitalize(county.county, true),
@@ -190,7 +197,7 @@ export const covidApi = createApi({
             county,
             coordinates,
             updatedAt,
-            stats
+            stats,
           };
         }),
     }),
@@ -206,11 +213,15 @@ export const covidApi = createApi({
       query: () => `vaccine/coverage/countries`,
       transformResponse: (response) =>
         response.map((country) => ({
-          vaccines: cartesianCoordinateConverter(country.timeline),
+          cases: cartesianCoordinateConverter(country.timeline),
+          deaths: [],
+          recovered: [],
           hasTimelineSequence:
             typeof country.timeline === "number" ? false : true,
           country: country.country,
+          provinces: "",
           state: "",
+          county: "",
           updatedAt: country.updatedAt ?? 0,
           population: country.population ?? 0,
         })),
@@ -226,11 +237,15 @@ export const covidApi = createApi({
         return `vaccine/coverage/countries/${endpoint}`;
       },
       transformResponse: (response) => ({
-        vaccines: cartesianCoordinateConverter(response.timeline),
+        cases: cartesianCoordinateConverter(response.timeline),
+        deaths: [],
+        recovered: [],
         hasTimelineSequence:
           typeof response.timeline === "number" ? false : true,
         country: "",
+        provinces: "",
         state: "",
+        county: "",
         updatedAt: response.updatedAt ?? 0,
         population: response.population ?? 0,
       }),
@@ -239,11 +254,15 @@ export const covidApi = createApi({
       query: () => `vaccine/coverage/states`,
       transformResponse: (response) =>
         response.map((state) => ({
-          vaccines: cartesianCoordinateConverter(state.timeline),
+          cases: cartesianCoordinateConverter(state.timeline),
+          deaths: [],
+          recovered: [],
           hasTimelineSequence:
             typeof state.timeline === "number" ? false : true,
           country: "",
+          provinces: "",
           state: state.state,
+          county: "",
           updatedAt: response.updatedAt ?? 0,
           population: response.population ?? 0,
         })),
@@ -259,11 +278,15 @@ export const covidApi = createApi({
         return `vaccine/coverage/states/${endpoint}`;
       },
       transformResponse: (response) => ({
-        vaccines: cartesianCoordinateConverter(response.timeline),
+        cases: cartesianCoordinateConverter(response.timeline),
+        deaths: [],
+        recovered: [],
         hasTimelineSequence:
           typeof response.timeline === "number" ? false : true,
         country: "",
+        provinces: "",
         state: "",
+        county: "",
         updatedAt: response.updatedAt ?? 0,
         population: response.population ?? 0,
       }),

--- a/covid-mapper/api/covidApi.js
+++ b/covid-mapper/api/covidApi.js
@@ -183,15 +183,69 @@ export const covidApi = createApi({
     }),
     getTotalPeopleVaccinatedByCountries: builder.query({
       query: () => `vaccine/coverage/countries`,
+      transformResponse: (response) =>
+        response.map((country) => ({
+          vaccines: cartesianCoordinateConverter(country.timeline),
+          hasTimelineSequence:
+            typeof country.timeline === "number" ? false : true,
+          country: country.country,
+          state: "",
+          updatedAt: country.updatedAt ?? 0,
+          population: country.population ?? 0,
+        })),
     }),
     getTotalPeopleVaccinatedByCountry: builder.query({
-      query: (country) => `vaccine/coverage/countries/${country}`,
+      query: (country) => {
+        const endpoint = !country
+          ? "not-chosen"
+          : !country.length
+          ? "not-chosen"
+          : country.toLowerCase();
+
+        return `vaccine/coverage/countries/${endpoint}`;
+      },
+      transformResponse: (response) => ({
+        vaccines: cartesianCoordinateConverter(response.timeline),
+        hasTimelineSequence:
+          typeof response.timeline === "number" ? false : true,
+        country: "",
+        state: "",
+        updatedAt: response.updatedAt ?? 0,
+        population: response.population ?? 0,
+      }),
     }),
     getTotalPeopleVaccinatedByStates: builder.query({
       query: () => `vaccine/coverage/states`,
+      transformResponse: (response) =>
+        response.map((state) => ({
+          vaccines: cartesianCoordinateConverter(state.timeline),
+          hasTimelineSequence:
+            typeof state.timeline === "number" ? false : true,
+          country: "",
+          state: state.state,
+          updatedAt: response.updatedAt ?? 0,
+          population: response.population ?? 0,
+        })),
     }),
     getTotalPeopleVaccinatedByState: builder.query({
-      query: (state) => `vaccine/coverage/states/${state}`,
+      query: (state) => {
+        const endpoint = !state
+          ? "not-chosen"
+          : !state.length
+          ? "not-chosen"
+          : state.toLowerCase();
+
+        return `vaccine/coverage/states/${endpoint}`;
+      },
+      transformResponse: (response) => ({
+        vaccines: cartesianCoordinateConverter(response.timeline),
+        hasTimelineSequence:
+          typeof response.timeline === "number" ? false : true,
+        country: "",
+        state: "",
+        updatedAt: response.updatedAt ?? 0,
+        population: response.population ?? 0,
+      }),
     }),
   }),
 });

--- a/covid-mapper/features/drawer/DrawerMenu.js
+++ b/covid-mapper/features/drawer/DrawerMenu.js
@@ -13,6 +13,10 @@ import DrawerContent from "./DrawerContent";
 import {
   USSearchMapLayout,
   USViewMapLayout,
+  VaccineUSSearchMapLayout,
+  VaccineUSViewMapLayout,
+  VaccineWorldSearchMapLayout,
+  VaccineWorldViewMapLayout,
   WorldSearchMapLayout,
   WorldViewMapLayout,
 } from "../map-layout";
@@ -71,10 +75,22 @@ const DrawerMenu = () => {
         />
 
         {/* Vaccine */}
-        <Drawer.Screen name="World Vaccination Totals" component={MapLayout} />
-        <Drawer.Screen name="Country Vaccination Total" component={MapLayout} />
-        <Drawer.Screen name="US Vaccination Total" component={MapLayout} />
-        <Drawer.Screen name="State Vaccination Total" component={MapLayout} />
+        <Drawer.Screen
+          name="World Vaccination Totals"
+          component={VaccineWorldViewMapLayout}
+        />
+        <Drawer.Screen
+          name="Country Vaccination Total"
+          component={VaccineWorldSearchMapLayout}
+        />
+        <Drawer.Screen
+          name="US Vaccination Total"
+          component={VaccineUSViewMapLayout}
+        />
+        <Drawer.Screen
+          name="State Vaccination Total"
+          component={VaccineUSSearchMapLayout}
+        />
         <Drawer.Screen name="Trial Data" component={VaccineLayout} />
 
         {/* Bottom Content */}

--- a/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
@@ -144,7 +144,7 @@ const VaccineUSSearchMapLayout = () => {
       } else if (vaccinatedStateSuccess) {
         // Get the centered region.
         const centeredRegion = centroidRegion(
-          "countries",
+          "united_states",
           searchState,
           mapRegion,
           mapviewWidth,

--- a/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
@@ -1,0 +1,228 @@
+import React, { useEffect, useState, useRef, useCallback } from "react";
+import * as Location from "expo-location";
+import {
+  useWindowDimensions,
+  Animated,
+  Pressable,
+  Keyboard,
+} from "react-native";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+
+import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import MapComponent from "../map/Map";
+import Searchbar from "../searchbar/Searchbar";
+import { useGetTotalPeopleVaccinatedByStateQuery } from "../../api/covidApi";
+import { ErrorModal } from "../../commons/components/ErrorModal";
+import FloatingSearchButton from "../../commons/components/FloatingSearchButton/FloatingSearchButton";
+import { centroidRegion } from "../../utils";
+
+const fadeInSearchBar = (fadeAnim) => {
+  Animated.timing(fadeAnim, {
+    toValue: 1,
+    duration: 500,
+    useNativeDriver: true,
+  }).start();
+};
+
+const VaccineUSSearchMapLayout = () => {
+  // Searchbar animation
+  const [searchBarActive, setSearchBarActive] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  const [userLocation, setUserLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  const [sliderData, setSliderData] = useState(null);
+  const [dataError, setDataError] = useState({
+    error: false,
+    message: "",
+  });
+  const [sliderHeader, setSliderHeader] = useState(
+    "State in US Vaccinated Data"
+  );
+
+  const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
+
+  // Set the placeholder for the searchbar:
+  const searchPlaceholder = "Search by state";
+
+  // These are for storing the user's search inputs so that it could be inserted into
+  // the Redux Toolkit query hooks:
+  // -- for searching by state:
+  const [searchState, setSearchState] = useState("");
+
+  const {
+    data: vaccinatedStateData,
+    isFetching: vaccinatedStateFetching,
+    isSuccess: vaccinatedStateSuccess,
+    error: vaccinatedStateError,
+    refetch: refetchVaccinatedState,
+  } = useGetTotalPeopleVaccinatedByStateQuery(searchState);
+
+  const [mapRegion, setMapRegion] = useState({
+    latitude: 36.778259,
+    longitude: -119.417931,
+    latitudeDelta: 11.0922,
+    longitudeDelta: 11.0421,
+  });
+
+  /*
+     Hook for storing alert content rendered in Searchbar; need to invoke setter function with one of these arguments: 
+      
+     1. countryHistoricalData.province
+     2. usCountiesData.map(countyObj=>countyObj.county) 
+
+     Need to pass setter function to sub-apps' useEffects and 'searchOptionsAlertMessage' to Searchbar
+  */
+  const [searchOptionsAlertMessage, setSearchOptionsAlertMessage] = useState(
+    []
+  );
+
+  // -------Handles the modal
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
+  // ---------Bottom Sheet Modal useRef and useMemo
+  const bottomSheetModalRef = useRef(null);
+  // State to handle the opening/closing of the Slider
+  const [sliderButton, setSliderButton] = useState(true);
+
+  const handleSearchSubmit = (inputValue) => {
+    // There must be a input longer than 0 characters.
+    if (inputValue.length) {
+      // Refetch the State.
+      refetchVaccinatedState();
+
+      setSearchState(inputValue);
+    }
+  };
+
+  // Ask permission to obtain user's current location
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        setErrorMsg("Permission to access location was denied");
+
+        setUserLocation(mapRegion);
+        return;
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setUserLocation(location);
+    })();
+  }, []);
+
+  /* 
+    Location JSON structure is different for iOS and Android.
+    iOS: currentLocation 
+    Android: currentLocatoin.coords
+  */
+  let currentLocation = "Waiting..";
+  if (errorMsg) {
+    currentLocation = errorMsg;
+  } else if (userLocation) {
+    currentLocation = JSON.stringify(userLocation);
+  }
+
+  // To render to the slider if user entered a State.
+  useEffect(() => {
+    // First check if the user has entered a State and if the data is not being fetched.
+    if (searchState.length && !vaccinatedStateFetching) {
+      // After the fetch, check to see first if there are errors from the API.
+      if (vaccinatedStateError) {
+        setDataError({
+          error: true,
+          message: vaccinatedStateError.data.message,
+        });
+
+        // Reset the searchState to an empty string. This is the case if the user entered
+        // the wrong name of the State.
+        setSearchState("");
+
+        // Check to see if the API call was a success.
+      } else if (vaccinatedStateSuccess) {
+        // Get the centered region.
+        const centeredRegion = centroidRegion(
+          "countries",
+          searchState,
+          mapRegion,
+          mapviewWidth,
+          mapviewHeight
+        );
+
+        // Set the centered region.
+        setMapRegion(centeredRegion);
+
+        // Update the slider data to be displayed.
+        setSliderData(vaccinatedStateData);
+
+        // Update the slider header to display the user's selected State.
+        setSliderHeader(`${searchState} Vaccinated Data`);
+      }
+    }
+  }, [
+    searchState,
+    vaccinatedStateError,
+    vaccinatedStateFetching,
+    vaccinatedStateSuccess,
+  ]);
+
+  return (
+    <>
+      {dataError.error && (
+        <ErrorModal
+          errorMsg={dataError.message}
+          errorStatus={dataError.error}
+          setDataError={setDataError}
+        />
+      )}
+
+      <FloatingSearchButton
+        pressHandler={() => {
+          setSearchBarActive(!searchBarActive);
+          fadeInSearchBar(fadeAnim);
+        }}
+      ></FloatingSearchButton>
+      {searchBarActive ? (
+        <Searchbar
+          handleSearchSubmit={handleSearchSubmit}
+          searchPlaceholder={searchPlaceholder}
+          opacityLevel={fadeAnim}
+          handlePresentModalPress={handlePresentModalPress}
+        />
+      ) : (
+        <></>
+      )}
+
+      {!sliderData ? null : !sliderButton ? null : (
+        <PopupSliderButton
+          handlePresentModalPress={handlePresentModalPress}
+          setSliderButton={setSliderButton}
+        />
+      )}
+
+      <BottomSheetModalProvider>
+        {!dataError.error && sliderData && (
+          <PopupSlider
+            setSliderButton={setSliderButton}
+            sliderData={sliderData}
+            sliderHeader={sliderHeader}
+            bottomSheetModalRef={bottomSheetModalRef}
+          />
+        )}
+
+        <Pressable onPressOut={Keyboard.dismiss}>
+          <MapComponent
+            mapviewHeight={mapviewHeight}
+            mapviewRegion={mapRegion}
+            mapviewWidth={mapviewWidth}
+            userLocation={userLocation}
+          />
+        </Pressable>
+      </BottomSheetModalProvider>
+    </>
+  );
+};
+
+export default VaccineUSSearchMapLayout;

--- a/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
@@ -1,0 +1,120 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Keyboard, Pressable, useWindowDimensions } from "react-native";
+import * as Location from "expo-location";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+
+import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import MapComponent from "../map/Map";
+import { useGetTotalPeopleVaccinatedByStatesQuery } from "../../api/covidApi";
+
+const VaccineUSViewMapLayout = () => {
+  const {
+    data: statesVaccinatedData,
+    error: statesVaccinatedError,
+    isFetching: statesVaccinatedFetching,
+    isSuccess: statesVaccinatedSuccess,
+  } = useGetTotalPeopleVaccinatedByStatesQuery();
+
+  const [useLocation, setUserLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  const [sliderData, setSliderData] = useState(null);
+
+  const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
+
+  const sliderHeader = "World Vaccinated Data";
+  const mapRegion = {
+    latitude: 36.778259,
+    longitude: -119.417931,
+    latitudeDelta: 11.0922,
+    longitudeDelta: 11.0421,
+  };
+
+  /*
+     Hook for storing alert content rendered in Searchbar; need to invoke setter function with one of these arguments: 
+      
+     1. countryHistoricalData.province
+     2. usCountiesData.map(countyObj=>countyObj.county) 
+
+     Need to pass setter function to sub-apps' useEffects and 'searchOptionsAlertMessage' to Searchbar
+  */
+  const [searchOptionsAlertMessage, setSearchOptionsAlertMessage] = useState(
+    []
+  );
+
+  // -------Handles the modal
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
+  // ---------Bottom Sheet Modal useRef and useMemo
+  const bottomSheetModalRef = useRef(null);
+  // State to handle the opening/closing of the Slider
+  const [sliderButton, setSliderButton] = useState(false);
+
+  // Since it is null initially before it finishes the fetch.
+  useEffect(() => {
+    if (statesVaccinatedData) setSliderData(statesVaccinatedData);
+  }, [statesVaccinatedData]);
+
+  // To open the slider once data has been loaded
+  useEffect(() => {
+    if (sliderData) handlePresentModalPress();
+  }, [sliderData]);
+
+  // Ask permission to obtain user's current location
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        setErrorMsg("Permission to access location was denied");
+        return;
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setUserLocation(location);
+    })();
+  }, []);
+
+  /* 
+    Location JSON structure is different for iOS and Android.
+    iOS: currentLocation 
+    Android: currentLocatoin.coords
+  */
+  let currentLocation = "Waiting..";
+  if (errorMsg) {
+    currentLocation = errorMsg;
+  } else if (userLocation) {
+    currentLocation = JSON.stringify(userLocation);
+  }
+
+  return (
+    <>
+      {sliderData && sliderButton && (
+        <PopupSliderButton
+          handlePresentModalPress={handlePresentModalPress}
+          setSliderButton={setSliderButton}
+        />
+      )}
+
+      <BottomSheetModalProvider>
+        <PopupSlider
+          setSliderButton={setSliderButton}
+          sliderData={sliderData}
+          sliderHeader={sliderHeader}
+          bottomSheetModalRef={bottomSheetModalRef}
+        />
+
+        <Pressable onPressOut={Keyboard.dismiss}>
+          <MapComponent
+            mapviewHeight={mapviewHeight}
+            mapviewRegion={mapRegion}
+            mapviewWidth={mapviewWidth}
+            userLocation={userLocation}
+          />
+        </Pressable>
+      </BottomSheetModalProvider>
+    </>
+  );
+};
+
+export default VaccineUSViewMapLayout;

--- a/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
@@ -15,7 +15,7 @@ const VaccineUSViewMapLayout = () => {
     isSuccess: statesVaccinatedSuccess,
   } = useGetTotalPeopleVaccinatedByStatesQuery();
 
-  const [useLocation, setUserLocation] = useState(null);
+  const [userLocation, setUserLocation] = useState(null);
   const [errorMsg, setErrorMsg] = useState(null);
 
   const [sliderData, setSliderData] = useState(null);

--- a/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
@@ -22,7 +22,7 @@ const VaccineUSViewMapLayout = () => {
 
   const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
 
-  const sliderHeader = "World Vaccinated Data";
+  const sliderHeader = "US Vaccinated Data";
   const mapRegion = {
     latitude: 36.778259,
     longitude: -119.417931,

--- a/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
@@ -1,0 +1,226 @@
+import React, { useEffect, useState, useRef, useCallback } from "react";
+import * as Location from "expo-location";
+import {
+  useWindowDimensions,
+  Animated,
+  Pressable,
+  Keyboard,
+} from "react-native";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+
+import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import MapComponent from "../map/Map";
+import Searchbar from "../searchbar/Searchbar";
+import { useGetTotalPeopleVaccinatedByCountryQuery } from "../../api/covidApi";
+import { ErrorModal } from "../../commons/components/ErrorModal";
+import FloatingSearchButton from "../../commons/components/FloatingSearchButton/FloatingSearchButton";
+import { centroidRegion } from "../../utils";
+
+const fadeInSearchBar = (fadeAnim) => {
+  Animated.timing(fadeAnim, {
+    toValue: 1,
+    duration: 500,
+    useNativeDriver: true,
+  }).start();
+};
+
+const VaccineWorldSearchMapLayout = () => {
+  // Searchbar animation
+  const [searchBarActive, setSearchBarActive] = useState(false);
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  const [userLocation, setUserLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  const [sliderData, setSliderData] = useState(null);
+  const [dataError, setDataError] = useState({
+    error: false,
+    message: "",
+  });
+  const [sliderHeader, setSliderHeader] = useState("Country Vaccinated Data");
+
+  const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
+
+  // Set the placeholder for the searchbar:
+  const searchPlaceholder = "Search by country";
+
+  // These are for storing the user's search inputs so that it could be inserted into
+  // the Redux Toolkit query hooks:
+  // -- for searching by country:
+  const [searchCountry, setSearchCountry] = useState("");
+
+  const {
+    data: vaccinatedCountryData,
+    isFetching: vaccinatedCountryFetching,
+    isSuccess: vaccinatedCountrySuccess,
+    error: vaccinatedCountryError,
+    refetch: refetchVaccinatedCountry,
+  } = useGetTotalPeopleVaccinatedByCountryQuery(searchCountry);
+
+  const [mapRegion, setMapRegion] = useState({
+    latitude: 36.778259,
+    longitude: -119.417931,
+    latitudeDelta: 11.0922,
+    longitudeDelta: 11.0421,
+  });
+
+  /*
+     Hook for storing alert content rendered in Searchbar; need to invoke setter function with one of these arguments: 
+      
+     1. countryHistoricalData.province
+     2. usCountiesData.map(countyObj=>countyObj.county) 
+
+     Need to pass setter function to sub-apps' useEffects and 'searchOptionsAlertMessage' to Searchbar
+  */
+  const [searchOptionsAlertMessage, setSearchOptionsAlertMessage] = useState(
+    []
+  );
+
+  // -------Handles the modal
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
+  // ---------Bottom Sheet Modal useRef and useMemo
+  const bottomSheetModalRef = useRef(null);
+  // State to handle the opening/closing of the Slider
+  const [sliderButton, setSliderButton] = useState(true);
+
+  const handleSearchSubmit = (inputValue) => {
+    // There must be a input longer than 0 characters.
+    if (inputValue.length) {
+      // Refetch the Country.
+      refetchCountryHistorical();
+
+      setSearchCountry(inputValue);
+    }
+  };
+
+  // Ask permission to obtain user's current location
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        setErrorMsg("Permission to access location was denied");
+
+        setUserLocation(mapRegion);
+        return;
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setUserLocation(location);
+    })();
+  }, []);
+
+  /* 
+    Location JSON structure is different for iOS and Android.
+    iOS: currentLocation 
+    Android: currentLocatoin.coords
+  */
+  let currentLocation = "Waiting..";
+  if (errorMsg) {
+    currentLocation = errorMsg;
+  } else if (userLocation) {
+    currentLocation = JSON.stringify(userLocation);
+  }
+
+  // To render to the slider if user entered a country.
+  useEffect(() => {
+    // First check if the user has entered a Country and if the data is not being fetched.
+    if (searchCountry.length && !vaccinatedCountryFetching) {
+      // After the fetch, check to see first if there are errors from the API.
+      if (vaccinatedCountryError) {
+        setDataError({
+          error: true,
+          message: vaccinatedCountryError.data.message,
+        });
+
+        // Reset the searchCountry to an empty string. This is the case if the user entered
+        // the wrong name of the Country.
+        setSearchCountry("");
+
+        // Check to see if the API call was a success.
+      } else if (vaccinatedCountrySuccess) {
+        // Get the centered region.
+        const centeredRegion = centroidRegion(
+          "countries",
+          searchCountry,
+          mapRegion,
+          mapviewWidth,
+          mapviewHeight
+        );
+
+        // Set the centered region.
+        setMapRegion(centeredRegion);
+
+        // Update the slider data to be displayed.
+        setSliderData(vaccinatedCountryData);
+
+        // Update the slider header to display the user's selected Country.
+        setSliderHeader(`${searchCountry} Data`);
+      }
+    }
+  }, [
+    searchCountry,
+    vaccinatedCountryError,
+    vaccinatedCountryFetching,
+    vaccinatedCountrySuccess,
+  ]);
+
+  return (
+    <>
+      {dataError.error && (
+        <ErrorModal
+          errorMsg={dataError.message}
+          errorStatus={dataError.error}
+          setDataError={setDataError}
+        />
+      )}
+
+      <FloatingSearchButton
+        pressHandler={() => {
+          setSearchBarActive(!searchBarActive);
+          fadeInSearchBar(fadeAnim);
+        }}
+      ></FloatingSearchButton>
+      {searchBarActive ? (
+        <Searchbar
+          handleSearchSubmit={handleSearchSubmit}
+          searchPlaceholder={searchPlaceholder}
+          opacityLevel={fadeAnim}
+          handlePresentModalPress={handlePresentModalPress}
+        />
+      ) : (
+        <></>
+      )}
+
+      {!sliderData ? null : !sliderButton ? null : (
+        <PopupSliderButton
+          handlePresentModalPress={handlePresentModalPress}
+          setSliderButton={setSliderButton}
+        />
+      )}
+
+      <BottomSheetModalProvider>
+        {!dataError.error && sliderData && (
+          <PopupSlider
+            setSliderButton={setSliderButton}
+            sliderData={sliderData}
+            sliderHeader={sliderHeader}
+            bottomSheetModalRef={bottomSheetModalRef}
+          />
+        )}
+
+        <Pressable onPressOut={Keyboard.dismiss}>
+          <MapComponent
+            mapviewHeight={mapviewHeight}
+            mapviewRegion={mapRegion}
+            mapviewWidth={mapviewWidth}
+            userLocation={userLocation}
+          />
+        </Pressable>
+      </BottomSheetModalProvider>
+    </>
+  );
+};
+
+export default VaccineWorldSearchMapLayout;

--- a/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
@@ -89,7 +89,7 @@ const VaccineWorldSearchMapLayout = () => {
     // There must be a input longer than 0 characters.
     if (inputValue.length) {
       // Refetch the Country.
-      refetchCountryHistorical();
+      refetchVaccinatedCountry();
 
       setSearchCountry(inputValue);
     }

--- a/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
@@ -15,7 +15,7 @@ const VaccineWorldViewMapLayout = () => {
     isSuccess: countriesVaccinatedSuccess,
   } = useGetTotalPeopleVaccinatedByCountriesQuery();
 
-  const [useLocation, setUserLocation] = useState(null);
+  const [userLocation, setUserLocation] = useState(null);
   const [errorMsg, setErrorMsg] = useState(null);
 
   const [sliderData, setSliderData] = useState(null);

--- a/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
@@ -1,0 +1,121 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Keyboard, Pressable, useWindowDimensions } from "react-native";
+import * as Location from "expo-location";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
+
+import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import MapComponent from "../map/Map";
+import { useGetTotalPeopleVaccinatedByCountriesQuery } from "../../api/covidApi";
+
+const VaccineWorldViewMapLayout = () => {
+  const {
+    data: countriesVaccinatedData,
+    error: countriesVaccinatedError,
+    isFetching: countriesVaccinatedFetching,
+    isLoading: countriesVaccinatedLoading,
+    isSuccess: countriesVaccinatedSuccess,
+  } = useGetTotalPeopleVaccinatedByCountriesQuery();
+
+  const [useLocation, setUserLocation] = useState(null);
+  const [errorMsg, setErrorMsg] = useState(null);
+
+  const [sliderData, setSliderData] = useState(null);
+
+  const { width: mapviewWidth, height: mapviewHeight } = useWindowDimensions();
+
+  const sliderHeader = "World Vaccinated Data";
+  const mapRegion = {
+    latitude: 36.778259,
+    longitude: -119.417931,
+    latitudeDelta: 11.0922,
+    longitudeDelta: 11.0421,
+  };
+
+  /*
+     Hook for storing alert content rendered in Searchbar; need to invoke setter function with one of these arguments: 
+      
+     1. countryHistoricalData.province
+     2. usCountiesData.map(countyObj=>countyObj.county) 
+
+     Need to pass setter function to sub-apps' useEffects and 'searchOptionsAlertMessage' to Searchbar
+  */
+  const [searchOptionsAlertMessage, setSearchOptionsAlertMessage] = useState(
+    []
+  );
+
+  // -------Handles the modal
+  const handlePresentModalPress = useCallback(() => {
+    bottomSheetModalRef.current?.present();
+  }, []);
+  // ---------Bottom Sheet Modal useRef and useMemo
+  const bottomSheetModalRef = useRef(null);
+  // State to handle the opening/closing of the Slider
+  const [sliderButton, setSliderButton] = useState(false);
+
+  // Since it is null initially before it finishes the fetch.
+  useEffect(() => {
+    if (countriesVaccinatedData) setSliderData(countriesVaccinatedData);
+  }, [countriesVaccinatedData]);
+
+  // To open the slider once data has been loaded
+  useEffect(() => {
+    if (sliderData) handlePresentModalPress();
+  }, [sliderData]);
+
+  // Ask permission to obtain user's current location
+  useEffect(() => {
+    (async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        setErrorMsg("Permission to access location was denied");
+        return;
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      setUserLocation(location);
+    })();
+  }, []);
+
+  /* 
+    Location JSON structure is different for iOS and Android.
+    iOS: currentLocation 
+    Android: currentLocatoin.coords
+  */
+  let currentLocation = "Waiting..";
+  if (errorMsg) {
+    currentLocation = errorMsg;
+  } else if (userLocation) {
+    currentLocation = JSON.stringify(userLocation);
+  }
+
+  return (
+    <>
+      {sliderData && sliderButton && (
+        <PopupSliderButton
+          handlePresentModalPress={handlePresentModalPress}
+          setSliderButton={setSliderButton}
+        />
+      )}
+
+      <BottomSheetModalProvider>
+        <PopupSlider
+          setSliderButton={setSliderButton}
+          sliderData={sliderData}
+          sliderHeader={sliderHeader}
+          bottomSheetModalRef={bottomSheetModalRef}
+        />
+
+        <Pressable onPressOut={Keyboard.dismiss}>
+          <MapComponent
+            mapviewHeight={mapviewHeight}
+            mapviewRegion={mapRegion}
+            mapviewWidth={mapviewWidth}
+            userLocation={userLocation}
+          />
+        </Pressable>
+      </BottomSheetModalProvider>
+    </>
+  );
+};
+
+export default VaccineWorldViewMapLayout;

--- a/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
@@ -12,7 +12,6 @@ const VaccineWorldViewMapLayout = () => {
     data: countriesVaccinatedData,
     error: countriesVaccinatedError,
     isFetching: countriesVaccinatedFetching,
-    isLoading: countriesVaccinatedLoading,
     isSuccess: countriesVaccinatedSuccess,
   } = useGetTotalPeopleVaccinatedByCountriesQuery();
 

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
@@ -84,6 +84,7 @@ const PopupSlider = ({
           renderItem={({ item }) => (
             <PopupSliderData
               cases={item.cases}
+              country={item.country}
               county={item.county}
               deaths={item.deaths}
               hasTimelineSequence={item.hasTimelineSequence}

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
@@ -65,6 +65,7 @@ const PopupSlider = ({
         <BottomSheetScrollView>
           <PopupSliderData
             cases={sliderData.cases}
+            country={sliderData.country}
             county={sliderData.county}
             deaths={sliderData.deaths}
             hasTimelineSequence={sliderData.hasTimelineSequence}

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
@@ -35,6 +35,7 @@ const SliderDataInfoValues = styled.Text`
 
 const PopupSliderData = ({
   cases,
+  country,
   county,
   deaths,
   hasTimelineSequence,
@@ -56,6 +57,14 @@ const PopupSliderData = ({
     )}
 
     <SliderDataInfo>
+      {country.length > 0 && (
+        <>
+          <SliderDataInfoHeader>Country</SliderDataInfoHeader>
+
+          <SliderDataInfoValues>{country}</SliderDataInfoValues>
+        </>
+      )}
+
       {provinces.length > 0 && (
         <>
           <SliderDataInfoHeader>Provinces</SliderDataInfoHeader>

--- a/covid-mapper/features/map-layout/index.js
+++ b/covid-mapper/features/map-layout/index.js
@@ -1,4 +1,5 @@
 export { default as USSearchMapLayout } from "./USSearchMapLayout";
 export { default as USViewMapLayout } from "./USViewMapLayout";
+export { default as VaccineWorldViewMapLayout } from "./VaccineWorldViewMapLayout";
 export { default as WorldSearchMapLayout } from "./WorldSearchMapLayout";
 export { default as WorldViewMapLayout } from "./WorldViewMapLayout";

--- a/covid-mapper/features/map-layout/index.js
+++ b/covid-mapper/features/map-layout/index.js
@@ -1,6 +1,7 @@
 export { default as USSearchMapLayout } from "./USSearchMapLayout";
 export { default as USViewMapLayout } from "./USViewMapLayout";
 export { default as VaccineUSViewMapLayout } from "./VaccineUSViewMapLayout";
+export { default as VaccineWorldSearchMapLayout } from "./VaccineWorldSearchMapLayout";
 export { default as VaccineWorldViewMapLayout } from "./VaccineWorldViewMapLayout";
 export { default as WorldSearchMapLayout } from "./WorldSearchMapLayout";
 export { default as WorldViewMapLayout } from "./WorldViewMapLayout";

--- a/covid-mapper/features/map-layout/index.js
+++ b/covid-mapper/features/map-layout/index.js
@@ -1,5 +1,6 @@
 export { default as USSearchMapLayout } from "./USSearchMapLayout";
 export { default as USViewMapLayout } from "./USViewMapLayout";
+export { default as VaccineUSViewMapLayout } from "./VaccineUSViewMapLayout";
 export { default as VaccineWorldViewMapLayout } from "./VaccineWorldViewMapLayout";
 export { default as WorldSearchMapLayout } from "./WorldSearchMapLayout";
 export { default as WorldViewMapLayout } from "./WorldViewMapLayout";

--- a/covid-mapper/features/map-layout/index.js
+++ b/covid-mapper/features/map-layout/index.js
@@ -1,5 +1,6 @@
 export { default as USSearchMapLayout } from "./USSearchMapLayout";
 export { default as USViewMapLayout } from "./USViewMapLayout";
+export { default as VaccineUSSearchMapLayout } from "./VaccineUSSearchMapLayout";
 export { default as VaccineUSViewMapLayout } from "./VaccineUSViewMapLayout";
 export { default as VaccineWorldSearchMapLayout } from "./VaccineWorldSearchMapLayout";
 export { default as VaccineWorldViewMapLayout } from "./VaccineWorldViewMapLayout";


### PR DESCRIPTION
## Changes
1. Created different maplayouts for the different vaccine endpoints, and rendered it to the Drawer route.

## Purpose
The user should be able to see a map on the different vaccine routes of their choice, and with searching the vaccinations based on state/county/province/country.

## Approach
The approach was to simply create different maplayout components for the vaccine endpoints and render it to the Drawer so that the user could search for vaccination rates in a particular place.

Closes #145 