### PR TITLE
Split `PopupSlider` component with slot pattern

### DIFF
--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -8,7 +8,11 @@ import {
 } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderArray,
+  PopupSliderButton,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
 import {
@@ -230,7 +234,7 @@ const USSearchMapLayout = () => {
           usCountiesData
         );
 
-        setSliderData(selectedCountyData);
+        setSliderData([selectedCountyData]);
 
         setSliderHeader(`${searchUSCounty} Data`);
       }
@@ -300,10 +304,11 @@ const USSearchMapLayout = () => {
           !dataError.error &&
           sliderData && (
             <PopupSlider
+              bottomSheetModalRef={bottomSheetModalRef}
               setSliderButton={setSliderButton}
               sliderData={sliderData}
               sliderHeader={sliderHeader}
-              bottomSheetModalRef={bottomSheetModalRef}
+              SliderStructureComponent={PopupSliderArray}
             />
           )}
 

--- a/covid-mapper/features/map-layout/USViewMapLayout.js
+++ b/covid-mapper/features/map-layout/USViewMapLayout.js
@@ -9,7 +9,11 @@ import * as Location from "expo-location";
 import { useWindowDimensions, Pressable, Keyboard } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSliderButton, PopupSlider } from "./components/popup-slider";
+import {
+  PopupSliderButton,
+  PopupSlider,
+  PopupSliderArray,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import { useGetTotalsAllStatesUSQuery } from "../../api/covidApi";
 import { ErrorModal } from "../../commons/components/ErrorModal";
@@ -128,10 +132,11 @@ const USViewMapLayout = () => {
 
       <BottomSheetModalProvider>
         <PopupSlider
+          bottomSheetModalRef={bottomSheetModalRef}
           setSliderButton={setSliderButton}
           sliderData={sliderData}
           sliderHeader={sliderHeader}
-          bottomSheetModalRef={bottomSheetModalRef}
+          SliderStructureComponent={PopupSliderArray}
         />
 
         <Pressable onPressOut={Keyboard.dismiss}>

--- a/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
@@ -8,7 +8,11 @@ import {
 } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderButton,
+  PopupSliderObject,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
 import { useGetTotalPeopleVaccinatedByStateQuery } from "../../api/covidApi";
@@ -205,10 +209,11 @@ const VaccineUSSearchMapLayout = () => {
       <BottomSheetModalProvider>
         {!dataError.error && sliderData && (
           <PopupSlider
+            bottomSheetModalRef={bottomSheetModalRef}
             setSliderButton={setSliderButton}
             sliderData={sliderData}
             sliderHeader={sliderHeader}
-            bottomSheetModalRef={bottomSheetModalRef}
+            SliderStructureComponent={PopupSliderObject}
           />
         )}
 

--- a/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
@@ -3,7 +3,11 @@ import { Keyboard, Pressable, useWindowDimensions } from "react-native";
 import * as Location from "expo-location";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderArray,
+  PopupSliderButton,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import { useGetTotalPeopleVaccinatedByStatesQuery } from "../../api/covidApi";
 
@@ -98,10 +102,11 @@ const VaccineUSViewMapLayout = () => {
 
       <BottomSheetModalProvider>
         <PopupSlider
+          bottomSheetModalRef={bottomSheetModalRef}
           setSliderButton={setSliderButton}
           sliderData={sliderData}
           sliderHeader={sliderHeader}
-          bottomSheetModalRef={bottomSheetModalRef}
+          SliderStructureComponent={PopupSliderArray}
         />
 
         <Pressable onPressOut={Keyboard.dismiss}>

--- a/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
@@ -8,7 +8,11 @@ import {
 } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderButton,
+  PopupSliderObject,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
 import { useGetTotalPeopleVaccinatedByCountryQuery } from "../../api/covidApi";
@@ -203,10 +207,11 @@ const VaccineWorldSearchMapLayout = () => {
       <BottomSheetModalProvider>
         {!dataError.error && sliderData && (
           <PopupSlider
+            bottomSheetModalRef={bottomSheetModalRef}
             setSliderButton={setSliderButton}
             sliderData={sliderData}
             sliderHeader={sliderHeader}
-            bottomSheetModalRef={bottomSheetModalRef}
+            SliderStructureComponent={PopupSliderObject}
           />
         )}
 

--- a/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
@@ -3,7 +3,11 @@ import { Keyboard, Pressable, useWindowDimensions } from "react-native";
 import * as Location from "expo-location";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderArray,
+  PopupSliderButton,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import { useGetTotalPeopleVaccinatedByCountriesQuery } from "../../api/covidApi";
 
@@ -98,10 +102,11 @@ const VaccineWorldViewMapLayout = () => {
 
       <BottomSheetModalProvider>
         <PopupSlider
+          bottomSheetModalRef={bottomSheetModalRef}
           setSliderButton={setSliderButton}
           sliderData={sliderData}
           sliderHeader={sliderHeader}
-          bottomSheetModalRef={bottomSheetModalRef}
+          SliderStructureComponent={PopupSliderArray}
         />
 
         <Pressable onPressOut={Keyboard.dismiss}>

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -8,7 +8,11 @@ import {
 } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderButton,
+  PopupSliderObject,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import Searchbar from "../searchbar/Searchbar";
 import {
@@ -299,10 +303,11 @@ const WorldSearchMapLayout = () => {
           !dataError.error &&
           sliderData && (
             <PopupSlider
+              bottomSheetModalRef={bottomSheetModalRef}
               setSliderButton={setSliderButton}
               sliderData={sliderData}
               sliderHeader={sliderHeader}
-              bottomSheetModalRef={bottomSheetModalRef}
+              SliderStructureComponent={PopupSliderObject}
             />
           )}
 

--- a/covid-mapper/features/map-layout/WorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldViewMapLayout.js
@@ -9,7 +9,11 @@ import * as Location from "expo-location";
 import { useWindowDimensions, Pressable, Keyboard } from "react-native";
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
-import { PopupSlider, PopupSliderButton } from "./components/popup-slider";
+import {
+  PopupSlider,
+  PopupSliderButton,
+  PopupSliderObject,
+} from "./components/popup-slider";
 import MapComponent from "../map/Map";
 import { useGetGlobalCovidStatsQuery } from "../../api/covidApi";
 import { ErrorModal } from "./../../commons/components/ErrorModal";
@@ -128,10 +132,11 @@ const WorldMapLayout = () => {
 
       <BottomSheetModalProvider>
         <PopupSlider
+          bottomSheetModalRef={bottomSheetModalRef}
           setSliderButton={setSliderButton}
           sliderData={sliderData}
           sliderHeader={sliderHeader}
-          bottomSheetModalRef={bottomSheetModalRef}
+          SliderStructureComponent={PopupSliderObject}
         />
 
         <Pressable onPressOut={Keyboard.dismiss}>

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSlider.js
@@ -1,13 +1,7 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import styled from "styled-components/native";
-import {
-  BottomSheetModal,
-  BottomSheetFlatList,
-  BottomSheetScrollView,
-} from "@gorhom/bottom-sheet";
-import { capitalize, loadMore } from "../../../../utils";
-import PopupSliderData from "./PopupSliderData";
-import Spinner from "../../../../commons/components/Spinner/Spinner";
+import { BottomSheetModal } from "@gorhom/bottom-sheet";
+import { capitalize } from "../../../../utils";
 
 const PopupSliderHeader = styled.View`
   padding-top: 17px;
@@ -21,45 +15,15 @@ const PopupSliderHeaderText = styled.Text`
   margin-right: 15px;
 `;
 
-const PopupContentContainer = styled.View`
-  display: flex;
-  justify-content: center;
-  padding: 2%;
-`;
-
-const PopupContent = styled.Text`
-  font-size: 15px;
-  color: #18181f;
-`;
-
-const PAGE_SIZE = 20;
-
 const PopupSlider = ({
+  bottomSheetModalRef,
   setSliderButton,
   sliderData,
   sliderHeader,
-  bottomSheetModalRef,
+  SliderStructureComponent,
 }) => {
-  // This is for the infinite scroll simulator to not render all the data at once.
-  const [dataLoader, setDataLoader] = useState([]);
-  // This is for the infinite scroll simulator to conditionally show the spinner.
-  const [isLoaderSpinner, setIsLoaderSpinner] = useState(true);
-  // This is for the infinite scroll simulator to paginate.
-  const [page, setPage] = useState(1);
   // This is the starting and ending height of the Slider.
   const snapPoints = useMemo(() => ["7%", "82%"], []);
-
-  // This is for the infinite scroll simulator that initializes the dataLoader if the
-  // API data is an array and not an object.
-  useEffect(() => {
-    if (
-      sliderData &&
-      typeof sliderData === "object" &&
-      Array.isArray(sliderData)
-    ) {
-      setDataLoader(sliderData.slice(0, PAGE_SIZE));
-    }
-  }, [sliderData]);
 
   if (!sliderData) return null;
 
@@ -83,64 +47,7 @@ const PopupSlider = ({
         </PopupSliderHeaderText>
       </PopupSliderHeader>
 
-      {/* Since the API data could either be an array or an object, this checks what data
-          structure it is. If it is an object, then display the data with no FlatList.
-          Otherwise, if it is an array, then display the data with the FlatList.
-      */}
-      {typeof sliderData === "object" && !Array.isArray(sliderData) ? (
-        <BottomSheetScrollView>
-          <PopupSliderData
-            cases={sliderData.cases}
-            country={sliderData.country}
-            county={sliderData.county}
-            deaths={sliderData.deaths}
-            hasTimelineSequence={sliderData.hasTimelineSequence}
-            population={sliderData.population}
-            provinces={sliderData.provinces}
-            recovered={sliderData.recovered}
-            state={sliderData.state}
-            updatedAt={sliderData.updatedAt}
-          />
-        </BottomSheetScrollView>
-      ) : (
-        <BottomSheetFlatList
-          data={dataLoader}
-          initialNumToRender={PAGE_SIZE}
-          onEndReached={() => {
-            // This is done because the onEndReached would still be activated even when
-            // you reach to the end of the Slider scroll.
-            if (dataLoader.length !== sliderData.length) {
-              setDataLoader((prevState) => {
-                const newData = loadMore(sliderData, page, PAGE_SIZE, setPage);
-
-                return prevState.concat(newData);
-              });
-            }
-
-            // If the length of the dataLoader equals the same as the sliderData, then stop
-            // the Spinner.
-            dataLoader.length === sliderData.length
-              ? setIsLoaderSpinner(false)
-              : setIsLoaderSpinner(true);
-          }}
-          ListFooterComponent={isLoaderSpinner ? <Spinner /> : null}
-          keyExtractor={(item, index) => `${item.county}-${index}`}
-          renderItem={({ item }) => (
-            <PopupSliderData
-              cases={item.cases}
-              country={item.country}
-              county={item.county}
-              deaths={item.deaths}
-              hasTimelineSequence={item.hasTimelineSequence}
-              population={item.population}
-              provinces={item.provinces}
-              recovered={item.recovered}
-              state={item.state}
-              updatedAt={item.updatedAt}
-            />
-          )}
-        />
-      )}
+      <SliderStructureComponent sliderData={sliderData} />
     </BottomSheetModal>
   );
 };

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderArray.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderArray.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { BottomSheetFlatList } from "@gorhom/bottom-sheet";
 
 import PopupSliderData from "./PopupSliderData";

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderArray.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderArray.js
@@ -1,0 +1,71 @@
+import React, { useEffect } from "react";
+import { BottomSheetFlatList } from "@gorhom/bottom-sheet";
+
+import PopupSliderData from "./PopupSliderData";
+import Spinner from "../../../../commons/components/Spinner/Spinner";
+import { loadMore } from "../../../../utils";
+
+const PAGE_SIZE = 20;
+
+const PopupSliderArray = ({ sliderData }) => {
+  // This is for the infinite scroll simulator to not render all the data at once.
+  const [dataLoader, setDataLoader] = useState([]);
+  // This is for the infinite scroll simulator to conditionally show the spinner.
+  const [isLoaderSpinner, setIsLoaderSpinner] = useState(true);
+  // This is for the infinite scroll simulator to paginate.
+  const [page, setPage] = useState(1);
+
+  // This is for the infinite scroll simulator that initializes the dataLoader if the
+  // API data is an array and not an object.
+  useEffect(() => {
+    if (
+      sliderData &&
+      typeof sliderData === "object" &&
+      Array.isArray(sliderData)
+    ) {
+      setDataLoader(sliderData.slice(0, PAGE_SIZE));
+    }
+  }, []);
+
+  return (
+    <BottomSheetFlatList
+      data={dataLoader}
+      initialNumToRender={PAGE_SIZE}
+      onEndReached={() => {
+        // This is done because the onEndReached would still be activated even when
+        // you reach to the end of the Slider scroll.
+        if (dataLoader.length !== sliderData.length) {
+          setDataLoader((prevState) => {
+            const newData = loadMore(sliderData, page, PAGE_SIZE, setPage);
+
+            return prevState.concat(newData);
+          });
+        }
+
+        // If the length of the dataLoader equals the same as the sliderData, then stop
+        // the Spinner.
+        dataLoader.length === sliderData.length
+          ? setIsLoaderSpinner(false)
+          : setIsLoaderSpinner(true);
+      }}
+      ListFooterComponent={isLoaderSpinner ? <Spinner /> : null}
+      keyExtractor={(item, index) => `${item.county}-${index}`}
+      renderItem={({ item }) => (
+        <PopupSliderData
+          cases={item.cases}
+          country={item.country}
+          county={item.county}
+          deaths={item.deaths}
+          hasTimelineSequence={item.hasTimelineSequence}
+          population={item.population}
+          provinces={item.provinces}
+          recovered={item.recovered}
+          state={item.state}
+          updatedAt={item.updatedAt}
+        />
+      )}
+    />
+  );
+};
+
+export default PopupSliderArray;

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderObject.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderObject.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet";
+
+import PopupSliderData from "./PopupSliderData";
+
+const PopupSliderObject = ({ sliderData }) => (
+  <BottomSheetScrollView>
+    <PopupSliderData
+      cases={sliderData.cases}
+      country={sliderData.country}
+      county={sliderData.county}
+      deaths={sliderData.deaths}
+      hasTimelineSequence={sliderData.hasTimelineSequence}
+      population={sliderData.population}
+      provinces={sliderData.provinces}
+      recovered={sliderData.recovered}
+      state={sliderData.state}
+      updatedAt={sliderData.updatedAt}
+    />
+  </BottomSheetScrollView>
+);
+
+export default PopupSliderObject;

--- a/covid-mapper/features/map-layout/components/popup-slider/index.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/index.js
@@ -1,2 +1,4 @@
 export { default as PopupSlider } from "./PopupSlider";
+export { default as PopupSliderArray } from "./PopupSliderArray";
 export { default as PopupSliderButton } from "./PopupSliderButton";
+export { default as PopupSliderObject } from "./PopupSliderObject";


### PR DESCRIPTION
## Changes
1. Created two components to split the `PopupSlider` where one handles the array while the other handles the object.
2. Refactored the `PopupSlider` to render its `SliderStructureComponent` prop which uses the slot pattern, and makes this component cleaner.
3. Refactored all the maplayouts to use the slot pattern for the `PopupSlider` component based on what data structure the API gives out.

## Purpose
Currently, the `PopupSlider` component handles both the array and the object from the API data in order to render a non-FlatList or one with the FlatList with the functionalities for both. Some of the maplayouts do not have an array of data, or they do, or they have both. So, the `PopupSlider` should be broken up into two different components for the data object and array in order to make the code more readable, the maplayouts could use the relevant component to render, and to avoid any future unseen bugs (since `PopupSlider` is handling both the array and object data to render).

## Approach
To achieve this based on the information from the **Purpose** section, a slot pattern was used where the `SliderStructureComponent` prop in `PopupSlider` would act as the slot (the name of the prop was chosen to represent on the type of data structure the API would give). Once two new components was created (`PopupSliderArray` and `PopupSliderObject`) and the `PopupSlider` was refactored, all the maplayouts were refactored to use the slot pattern.

The only slight adjustment was in the `USSearchMapLayout` component where it would either show an array of all the counties in a selected state in the US, or an object of the selected county in the state. To make it easier on not using conditionals on whether to pass `PopupSliderArray` or `PopupSliderObject` in the slot pattern, an array was wrapped in setState on line 237 (`setSliderData([selectedCountyData])`) in order to just use `PopupSliderArray`.

## Learning
[Pass Multiple Children to a React Component with Slots](https://daveceddia.com/pluggable-slots-in-react-components/).

[React Pass Component As Prop with Props](https://www.tutorialsplane.com/react-pass-component-as-prop-with-props-example/).

Closes #165 