### PR TITLE
Trim whitespaces

### DIFF
--- a/covid-mapper/features/map-layout/MapLayout.js
+++ b/covid-mapper/features/map-layout/MapLayout.js
@@ -149,7 +149,8 @@ const MapLayout = ({ route }) => {
   const bottomSheetModalRef = useRef(null);
   const snapPoints = useMemo(() => ["25%", "82%"], []);
 
-  const handleSearchSubmit = (inputValue) => {
+  const handleSearchSubmit = (searchInput) => {
+    const inputValue=searchInput.trim();
     // Based on the name of the route to update particular states.
     if (routeName === "Country Province Stats") {
       // If there are no inputs for this, then it is the initial start.

--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -112,7 +112,8 @@ const USSearchMapLayout = () => {
   // State to handle the opening/closing of the Slider
   const [sliderButton, setSliderButton] = useState(true);
 
-  const handleSearchSubmit = (inputValue) => {
+  const handleSearchSubmit = (searchInput) => {
+    const inputValue = searchInput.trim();
     // There must be a input longer than 0 characters.
     if (inputValue.length) {
       // If there are no inputs for State, then it is the initial start.

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -113,7 +113,8 @@ const WorldSearchMapLayout = () => {
   // State to handle the opening/closing of the Slider
   const [sliderButton, setSliderButton] = useState(true);
 
-  const handleSearchSubmit = (inputValue) => {
+  const handleSearchSubmit = (searchInput) => {
+    const inputValue = searchInput.trim();
     // There must be a input longer than 0 characters.
     if (inputValue.length) {
       // If there are no inputs for this, then it is the initial start which is searching by country first before province.


### PR DESCRIPTION

## Changes
1. Added `.trim()` to get rid of whitespaces from both ends of search input value.

## Purpose
Prevent error.

## Approach
Use `String.prototype.trim()`.


Closes #171 