### PR TITLE
convert response.updated to readable string from miliseconds

### DIFF
--- a/covid-mapper/api/covidApi.js
+++ b/covid-mapper/api/covidApi.js
@@ -21,8 +21,7 @@ export const covidApi = createApi({
         provinces: "",
         state: "",
         county: "",
-        updatedAt: response.cases ?? 0,
-        population: response.population ?? 0,
+        updatedAt: new Date(response.updated).toString() ?? 0, // response.updated is in miliseconds since Jan 1, 1970, need to convert to string 
       }),
     }),
     getEachCountriesTotals: builder.query({

--- a/covid-mapper/api/covidApi.js
+++ b/covid-mapper/api/covidApi.js
@@ -21,6 +21,7 @@ export const covidApi = createApi({
         provinces: "",
         state: "",
         county: "",
+        population: response.population ?? 0,
         updatedAt: new Date(response.updated).toString() ?? 0, // response.updated is in miliseconds since Jan 1, 1970, need to convert to string 
       }),
     }),

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
@@ -55,7 +55,6 @@ const PopupSliderData = ({
   updatedAt,
 }) => {
   const divideBy = population > 0 ? population : cases;
-
   return (
     <SliderDataWrapper>
       <SliderDataInfo>

--- a/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
+++ b/covid-mapper/features/map-layout/components/popup-slider/PopupSliderData.js
@@ -55,6 +55,7 @@ const PopupSliderData = ({
   updatedAt,
 }) => {
   const divideBy = population > 0 ? population : cases;
+
   return (
     <SliderDataWrapper>
       <SliderDataInfo>
@@ -90,7 +91,7 @@ const PopupSliderData = ({
           </SliderDataPopulation>
         )}
 
-        {updatedAt > 0 && (
+        {typeof updatedAt === "string" && (
           <SliderDataUpdate>(updated on {updatedAt})</SliderDataUpdate>
         )}
 


### PR DESCRIPTION
## Changes
1. Convert milliseconds to date string in `covidApi`.
2. `response.population` somehow got deleted and wasn't rendered in Bottom Sheet Modal. Added it back into `covidApi`.

## Purpose
Date conversion, small fix.

## Approach
Date.toString(), RTK query.

Closes #207 