### PR TITLE
Previous Region Button Margin

### DIFF
--- a/covid-mapper/commons/components/PreviousRegionButton/styles.js
+++ b/covid-mapper/commons/components/PreviousRegionButton/styles.js
@@ -2,13 +2,13 @@ import styled from "styled-components/native";
 
 export const PreviousRegionWrapper = styled.View`
   height: 25px;
-  padding-right: 10px;
-  padding-left: 10px;
+  padding: 0 10px;
   background-color: #808B89;
   border: 0.5px solid #c6c6d1;
   border-radius: 50px;
   align-items: center;
   justify-content: center;
+  margin-left: 110px;
 `;
 
 export const PreviousRegionTitle = styled.Text`


### PR DESCRIPTION
## Changes
1. Add margin on the left of the `PreviousRegionButton` to place it in the center of the screen. 


## Purpose
It would make it easier for both left and right handed users to access the button if it is in the middle of the screen. 


Closes #212