### PR TITLE
Fixed user location permission errors

### DIFF
--- a/covid-mapper/features/map-layout/USSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/USSearchMapLayout.js
@@ -144,6 +144,11 @@ const USSearchMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/USViewMapLayout.js
+++ b/covid-mapper/features/map-layout/USViewMapLayout.js
@@ -45,12 +45,12 @@ const USViewMapLayout = () => {
       mapviewWidth) /
       mapviewHeight;
 
-  const mapRegion = {
+  const [mapRegion, setMapRegion] = useState({
     latitude: initialLatitude,
     longitude: initialLongitude,
     latitudeDelta: initialLatitudeDelta,
     longitudeDelta: initialLongitudeDelta,
-  };
+  });
 
   // -------Handles the modal
   const handlePresentModalPress = useCallback(() => {
@@ -97,6 +97,11 @@ const USViewMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
@@ -111,8 +111,6 @@ const VaccineUSSearchMapLayout = () => {
       let { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
         setErrorMsg("Permission to access location was denied");
-
-        setUserLocation(mapRegion);
         return;
       }
 

--- a/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSSearchMapLayout.js
@@ -116,6 +116,11 @@ const VaccineUSSearchMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineUSViewMapLayout.js
@@ -40,12 +40,12 @@ const VaccineUSViewMapLayout = () => {
       mapviewWidth) /
       mapviewHeight;
 
-  const mapRegion = {
+  const [mapRegion, setMapRegion] = useState({
     latitude: initialLatitude,
     longitude: initialLongitude,
     latitudeDelta: initialLatitudeDelta,
     longitudeDelta: initialLongitudeDelta,
-  };
+  });
 
   // -------Handles the modal
   const handlePresentModalPress = useCallback(() => {
@@ -77,6 +77,11 @@ const VaccineUSViewMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
@@ -116,6 +116,11 @@ const VaccineWorldSearchMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldSearchMapLayout.js
@@ -111,8 +111,6 @@ const VaccineWorldSearchMapLayout = () => {
       let { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
         setErrorMsg("Permission to access location was denied");
-
-        setUserLocation(mapRegion);
         return;
       }
 

--- a/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/VaccineWorldViewMapLayout.js
@@ -42,12 +42,12 @@ const VaccineWorldViewMapLayout = () => {
       mapviewWidth) /
       mapviewHeight;
 
-  const mapRegion = {
+  const [mapRegion, setMapRegion] = useState({
     latitude: initialLatitude,
     longitude: initialLongitude,
     latitudeDelta: initialLatitudeDelta,
     longitudeDelta: initialLongitudeDelta,
-  };
+  });
 
   // -------Handles the modal
   const handlePresentModalPress = useCallback(() => {
@@ -79,6 +79,11 @@ const VaccineWorldViewMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -146,8 +146,6 @@ const WorldSearchMapLayout = () => {
       let { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== "granted") {
         setErrorMsg("Permission to access location was denied");
-
-        setUserLocation(mapRegion);
         return;
       }
 

--- a/covid-mapper/features/map-layout/WorldSearchMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldSearchMapLayout.js
@@ -151,6 +151,11 @@ const WorldSearchMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 

--- a/covid-mapper/features/map-layout/WorldViewMapLayout.js
+++ b/covid-mapper/features/map-layout/WorldViewMapLayout.js
@@ -47,12 +47,12 @@ const WorldMapLayout = () => {
       mapviewWidth) /
       mapviewHeight;
 
-  const mapRegion = {
+  const [mapRegion, setMapRegion] = useState({
     latitude: initialLatitude,
     longitude: initialLongitude,
     latitudeDelta: initialLatitudeDelta,
     longitudeDelta: initialLongitudeDelta,
-  };
+  });
 
   // -------Handles the modal
   const handlePresentModalPress = useCallback(() => {
@@ -99,6 +99,11 @@ const WorldMapLayout = () => {
 
       let location = await Location.getCurrentPositionAsync({});
       setUserLocation(location);
+      setMapRegion((prevRegion) => ({
+        ...prevRegion,
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+      }));
     })();
   }, []);
 


### PR DESCRIPTION
## Changes
1. Removed the default location to the user if they did not provide their location.
2. Fixed the view of the region to display the user's location.

## Purpose
When the user does not provide a location, there should not be any errors when they go to a drawer navigation. Yet, an error appears when the user searches for a location stating that a property of `coords` is undefined, and the fix for this was to remove the default location set to the `userLocation` since it does not have a `coords` property.

Another fix was changing the region of the map to display the user's location, if they provide it.

Closes #204 